### PR TITLE
ci: fix CodeQL SARIF upload permissions in DevSecOps workflow

### DIFF
--- a/.github/workflows/devsecops.yml
+++ b/.github/workflows/devsecops.yml
@@ -81,6 +81,8 @@ jobs:
   sast-go:
     name: SAST (Go)
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -107,7 +109,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload gosec results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always() && hashFiles('gosec-results.sarif') != ''
         with:
           sarif_file: gosec-results.sarif


### PR DESCRIPTION
## Summary

Fixes the `SAST (Go)` job failure caused by missing `security-events: write` permission required by `github/codeql-action/upload-sarif` to upload SARIF results to GitHub's Code Scanning API.

## Changes

- **Added** `security-events: write` permission to the `sast-go` job
- **Updated** `github/codeql-action/upload-sarif` from `@v3` to `@v4` (deprecated version)
- **Branch target:** `develop`

## Error fixed

```
Resource not accessible by integration - https://docs.github.com/rest
```