### PR TITLE
fix(frontend): add error logging to 13 empty catch blocks

### DIFF
--- a/frontend/src/lib/components/EmojiPicker.svelte
+++ b/frontend/src/lib/components/EmojiPicker.svelte
@@ -132,7 +132,8 @@
         recentEmojis = JSON.parse(stored);
         categories[0].emojis = recentEmojis;
       }
-    } catch {
+    } catch (err) {
+      console.error('[EmojiPicker] Failed to load recent emojis:', err);
       recentEmojis = [];
     }
   }
@@ -141,8 +142,8 @@
   function saveRecentEmojis() {
     try {
       localStorage.setItem(RECENT_EMOJIS_KEY, JSON.stringify(recentEmojis));
-    } catch {
-      // Ignore localStorage errors
+    } catch (err) {
+      console.error('[EmojiPicker] Failed to save recent emojis:', err);
     }
   }
 

--- a/frontend/src/lib/components/MarkdownRenderer.svelte
+++ b/frontend/src/lib/components/MarkdownRenderer.svelte
@@ -88,7 +88,8 @@
     try {
       const parsed = new URL(url);
       return ['http:', 'https:'].includes(parsed.protocol);
-    } catch {
+    } catch (err) {
+      console.error('[MarkdownRenderer] URL validation error:', err);
       return false;
     }
   }

--- a/frontend/src/lib/components/OfflineBanner.svelte
+++ b/frontend/src/lib/components/OfflineBanner.svelte
@@ -59,7 +59,8 @@
         // Still offline - show feedback
         reconnecting = false;
       }
-    } catch {
+    } catch (err) {
+      console.error('[OfflineBanner] Connectivity check failed:', err);
       reconnecting = false;
     }
   }

--- a/frontend/src/lib/components/VoiceCallOverlay.svelte
+++ b/frontend/src/lib/components/VoiceCallOverlay.svelte
@@ -65,8 +65,8 @@
 				const { x, y } = JSON.parse(savedPosition);
 				positionX = x;
 				positionY = y;
-			} catch {
-				// Ignore parse errors
+			} catch (err) {
+				console.error('[VoiceCallOverlay] Failed to load saved position:', err);
 			}
 		}
 

--- a/frontend/src/lib/components/WebhookManager.svelte
+++ b/frontend/src/lib/components/WebhookManager.svelte
@@ -46,8 +46,8 @@
 				try {
 					const channelWebhooks = await api.get<Webhook[]>(`/channels/${channel.id}/webhooks`);
 					allWebhooks.push(...channelWebhooks);
-				} catch {
-					// Skip channels we can't access
+				} catch (err) {
+					console.error('[WebhookManager] Failed to load webhooks for channel:', channel.id, err);
 				}
 			}
 			webhooks = allWebhooks;

--- a/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
+++ b/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
@@ -50,7 +50,8 @@
 			if (stored) {
 				recentSounds = JSON.parse(stored);
 			}
-		} catch {
+		} catch (err) {
+			console.error('[SoundboardPicker] Failed to load recent sounds:', err);
 			recentSounds = [];
 		}
 	}
@@ -59,8 +60,8 @@
 	function saveRecentSounds() {
 		try {
 			localStorage.setItem(RECENT_SOUNDS_KEY, JSON.stringify(recentSounds));
-		} catch {
-			// Ignore localStorage errors
+		} catch (err) {
+			console.error('[SoundboardPicker] Failed to save recent sounds:', err);
 		}
 	}
 
@@ -93,8 +94,8 @@
 				try {
 					const serverResponse = await api.get<Sound[]>(`/servers/${$currentServer.id}/soundboard`);
 					serverSounds = serverResponse || [];
-				} catch {
-					// Server might not have sounds or user might not have access
+				} catch (err) {
+					console.error('[SoundboardPicker] Failed to load server sounds:', err);
 					serverSounds = [];
 				}
 			}

--- a/frontend/src/lib/components/stickers/StickerPicker.svelte
+++ b/frontend/src/lib/components/stickers/StickerPicker.svelte
@@ -46,7 +46,8 @@
 			if (stored) {
 				recentStickers = JSON.parse(stored);
 			}
-		} catch {
+		} catch (err) {
+			console.error('[StickerPicker] Failed to load recent stickers:', err);
 			recentStickers = [];
 		}
 	}
@@ -55,8 +56,8 @@
 	function saveRecentStickers() {
 		try {
 			localStorage.setItem(RECENT_STICKERS_KEY, JSON.stringify(recentStickers));
-		} catch {
-			// Ignore localStorage errors
+		} catch (err) {
+			console.error('[StickerPicker] Failed to save recent stickers:', err);
 		}
 	}
 
@@ -89,8 +90,8 @@
 				try {
 					const serverResponse = await api.get<Sticker[]>(`/servers/${$currentServer.id}/stickers`);
 					serverStickers = serverResponse || [];
-				} catch {
-					// Server might not have stickers or user might not have access
+				} catch (err) {
+					console.error('[StickerPicker] Failed to load server stickers:', err);
 					serverStickers = [];
 				}
 			}

--- a/frontend/src/routes/app-directory/+page.svelte
+++ b/frontend/src/routes/app-directory/+page.svelte
@@ -151,7 +151,8 @@
 			userReview = { rating: review.rating, review_text: review.review_text };
 			reviewText = review.review_text || '';
 			reviewRating = review.rating;
-		} catch {
+		} catch (err) {
+			console.error('[AppDirectory] Failed to load user review:', err);
 			userReview = null;
 		}
 	}


### PR DESCRIPTION
Add console.error with component tags to all silent catch blocks
across 8 files. Errors are now logged instead of being swallowed.

Files affected:
- SoundboardPicker.svelte: load/save recent sounds, server sounds
- StickerPicker.svelte: load/save recent stickers, server stickers
- EmojiPicker.svelte: load/save recent emojis
- VoiceCallOverlay.svelte: load saved position
- OfflineBanner.svelte: connectivity check
- WebhookManager.svelte: channel webhook loading
- MarkdownRenderer.svelte: URL validation
- app-directory: user review loading

Refs: TASK_QUEUE.md P2 - Frontend Empty Catch Blocks (13 occurrences)
