### PR TITLE
fix(templates): capture server settings when serializing to template

### DIFF
--- a/.github/workflows/chat-history-test.yml
+++ b/.github/workflows/chat-history-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
           
       - name: Install Playwright
         run: |

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,8 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - govet

--- a/PRDs/2026-03-29_activities-games-integration.md
+++ b/PRDs/2026-03-29_activities-games-integration.md
@@ -1,0 +1,117 @@
+# Activities & Games Integration PRD
+
+## Feature Overview
+Rich presence system with gaming status, Discord Activities integration, and social gaming features within Hearth.
+
+## Discord Equivalent
+Discord Rich Presence, Discord Activities, Gaming Status - Deep integration with games and social activities.
+
+## User Value Proposition
+- **Social Gaming**: See what games friends are playing, join them directly
+- **Community Building**: Organize gaming sessions, tournaments, and events around games
+- **Rich Context**: Show detailed game status (what level, which character, etc.)
+- **Activity Discovery**: Find new games and activities through friends' activity
+
+## Technical Complexity Estimate
+**P1** - Medium-high complexity
+
+## Implementation Sketch
+### Rich Presence System
+- Game detection through running processes
+- Rich presence API for games to provide detailed status
+- Custom activity statuses (listening to music, watching streams, etc.)
+- Activity history and statistics
+
+### Discord Activities Integration
+- Embed web-based games and activities directly in channels
+- Party system for multiplayer activities
+- Activity invitations and joining
+- Screen sharing integration for shared experiences
+
+### Gaming Features
+- "Join Game" buttons when friends are playing multiplayer games
+- Game library integration (Steam, Epic, etc.)
+- Gaming status privacy controls
+- Game-based server discovery
+
+### Backend Changes
+```go
+type Activity struct {
+    ID          string    `json:"id"`
+    Name        string    `json:"name"`
+    Type        int       `json:"type"` // 0=game, 1=streaming, 2=listening, 3=watching, 5=competing
+    URL         string    `json:"url,omitempty"`
+    CreatedAt   int64     `json:"created_at"`
+    Timestamps  *struct {
+        Start int64 `json:"start,omitempty"`
+        End   int64 `json:"end,omitempty"`
+    } `json:"timestamps,omitempty"`
+    ApplicationID string   `json:"application_id,omitempty"`
+    Details       string   `json:"details,omitempty"`
+    State         string   `json:"state,omitempty"`
+    Party         *struct {
+        ID   string `json:"id,omitempty"`
+        Size []int  `json:"size,omitempty"` // [current, max]
+    } `json:"party,omitempty"`
+    Assets *struct {
+        LargeImage string `json:"large_image,omitempty"`
+        LargeText  string `json:"large_text,omitempty"`
+        SmallImage string `json:"small_image,omitempty"`
+        SmallText  string `json:"small_text,omitempty"`
+    } `json:"assets,omitempty"`
+    Secrets *struct {
+        Join     string `json:"join,omitempty"`
+        Spectate string `json:"spectate,omitempty"`
+        Match    string `json:"match,omitempty"`
+    } `json:"secrets,omitempty"`
+}
+```
+
+### Frontend Changes
+- User profile showing current activity
+- Activity status in member lists and presence indicators
+- Game invitation system
+- Activity-based server recommendations
+- Embedded activity launcher for supported games
+
+### Database Schema
+```sql
+CREATE TABLE user_activities (
+    user_id UUID NOT NULL,
+    activity_data JSONB NOT NULL,
+    started_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (user_id)
+);
+
+CREATE TABLE activity_invites (
+    id UUID PRIMARY KEY,
+    from_user_id UUID NOT NULL,
+    to_user_id UUID NOT NULL,
+    activity_data JSONB NOT NULL,
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE gaming_sessions (
+    id UUID PRIMARY KEY,
+    server_id UUID,
+    channel_id UUID,
+    game_name VARCHAR(255) NOT NULL,
+    participants JSONB, -- array of user_ids
+    started_at TIMESTAMP DEFAULT NOW(),
+    ended_at TIMESTAMP
+);
+```
+
+## Dependencies
+- Rich presence API development
+- Game detection system (desktop app integration)
+- OAuth integrations with gaming platforms
+- WebRTC for activity screen sharing
+
+## Success Metrics
+- Percentage of users with active game status
+- Game invitation acceptance rate
+- Activity-based friend connections
+- Time spent in gaming-related channels

--- a/PRDs/2026-03-29_advanced-message-search.md
+++ b/PRDs/2026-03-29_advanced-message-search.md
@@ -1,0 +1,106 @@
+# Advanced Message Search PRD
+
+## Feature Overview
+Comprehensive message search system with filters, indexing, and advanced query capabilities across servers and DMs.
+
+## Discord Equivalent
+Discord's message search with filters for author, date range, channel, file attachments, mentions, and content.
+
+## User Value Proposition
+- **Information Retrieval**: Quickly find past conversations, decisions, and shared files
+- **Knowledge Management**: Transform chat history into searchable knowledge base
+- **Productivity**: Reduce time spent scrolling through message history
+- **Legal Compliance**: Enable audit trails and record keeping for enterprise use
+
+## Technical Complexity Estimate
+**P1** - High complexity
+
+## Implementation Sketch
+### Search Capabilities
+- Full-text search across message content
+- Filter by: author, channel, date range, has attachments, mentions, reactions
+- Search operators: exact phrases, exclusions, logical AND/OR
+- Search within results for refinement
+- Saved search queries
+
+### Search Interface
+- Global search bar accessible from any context
+- Advanced search modal with filter UI
+- Search results with message context and jump-to functionality
+- Search suggestions and autocomplete
+- Recent searches history
+
+### Backend Architecture
+**Search Index Service (Elasticsearch/OpenSearch)**
+```json
+{
+  "message_id": "uuid",
+  "content": "searchable text content",
+  "author_id": "uuid",
+  "author_name": "display name",
+  "channel_id": "uuid",
+  "channel_name": "channel name",
+  "server_id": "uuid",
+  "server_name": "server name",
+  "timestamp": "2026-03-29T10:00:00Z",
+  "message_type": "default|reply|thread_starter",
+  "has_attachments": true,
+  "attachment_types": ["image", "file"],
+  "mentions": ["uuid1", "uuid2"],
+  "reactions": ["👍", "❤️"],
+  "thread_id": "uuid",
+  "reply_to": "uuid"
+}
+```
+
+### Backend Changes
+- Message indexing pipeline (real-time and batch)
+- Search API with query parsing and permission filtering
+- Index management (creation, updates, deletions)
+- Search analytics and performance monitoring
+
+### Frontend Changes
+- Global search component with keyboard shortcuts (Ctrl+K)
+- Advanced search filters interface
+- Search results with infinite scrolling
+- Message context preview with jump-to-message functionality
+- Search suggestions and query building assistance
+
+### Database Schema
+```sql
+CREATE TABLE search_queries (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    query_text TEXT NOT NULL,
+    filters JSONB,
+    result_count INTEGER,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE search_bookmarks (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    query_name VARCHAR(255) NOT NULL,
+    query_text TEXT NOT NULL,
+    filters JSONB,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### Privacy & Permissions
+- Search respects channel permissions and server membership
+- Private/deleted message handling
+- User privacy controls for search inclusion
+- Server-level search permissions
+
+## Dependencies
+- Elasticsearch/OpenSearch cluster setup
+- Message indexing infrastructure
+- Permissions system integration
+- High-performance search API
+
+## Success Metrics
+- Search usage frequency per active user
+- Search result click-through rate
+- Average time from search to message found
+- Search query success rate (non-empty results)

--- a/PRDs/2026-03-29_server-boosts-premium.md
+++ b/PRDs/2026-03-29_server-boosts-premium.md
@@ -1,0 +1,86 @@
+# Server Boosts & Premium Features PRD
+
+## Feature Overview
+Server boost system with premium subscription tiers providing enhanced server capabilities and user perks.
+
+## Discord Equivalent
+Discord Nitro and Server Boosts - Premium subscriptions that unlock enhanced features for users and servers.
+
+## User Value Proposition
+- **Server Enhancement**: Higher quality audio, larger file uploads, more emoji slots, custom server banner
+- **User Benefits**: Global custom emoji usage, higher quality screen share, larger file uploads
+- **Community Investment**: Allow users to financially support their favorite communities
+- **Status Symbol**: Premium badges, exclusive features that show engagement level
+
+## Technical Complexity Estimate
+**P0** - High complexity (revenue-critical feature)
+
+## Implementation Sketch
+### Subscription Tiers
+**Hearth Basic** (Free)
+- Standard features as currently implemented
+
+**Hearth Plus** ($4.99/month)
+- 25MB file uploads (vs 8MB)
+- HD screen sharing (1080p vs 720p)
+- Custom emoji usage across servers
+- Premium support
+
+**Hearth Pro** ($9.99/month)
+- Everything in Plus
+- Server boost credits (2/month)
+- Custom status with emoji
+- Early access to beta features
+
+### Server Boost Benefits
+**Level 1** (2 boosts): 50 emoji slots, 64kbps voice quality
+**Level 2** (7 boosts): 100 emoji slots, 128kbps voice quality, server banner
+**Level 3** (15 boosts): 250 emoji slots, 256kbps voice quality, animated server icon
+
+### Backend Changes
+- Subscription management system with Stripe integration
+- Boost tracking per server
+- Feature flag system for premium capabilities
+- Usage tracking and enforcement (file size, quality limits)
+
+### Frontend Changes
+- Premium settings panels
+- Boost management interface
+- Visual indicators for premium features
+- Upgrade prompts and billing management
+
+### Database Schema
+```sql
+CREATE TABLE subscriptions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    tier VARCHAR(20) NOT NULL, -- 'plus', 'pro'
+    status VARCHAR(20) NOT NULL, -- 'active', 'cancelled', 'expired'
+    stripe_subscription_id VARCHAR(255),
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE server_boosts (
+    id UUID PRIMARY KEY,
+    server_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+ALTER TABLE servers ADD COLUMN boost_level INTEGER DEFAULT 0;
+ALTER TABLE servers ADD COLUMN boost_count INTEGER DEFAULT 0;
+```
+
+## Dependencies
+- Stripe/payment processing integration
+- Feature flag system implementation
+- File upload infrastructure modifications
+- Voice quality enhancement capabilities
+
+## Success Metrics
+- Premium subscription conversion rate
+- Server boost adoption rate
+- Monthly recurring revenue
+- Premium feature usage rates

--- a/PRDs/2026-03-29_server-categories.md
+++ b/PRDs/2026-03-29_server-categories.md
@@ -1,0 +1,113 @@
+# Server Categories PRD
+
+## Feature Overview
+Organizational system for grouping channels into collapsible categories with inherited permissions and visual hierarchy.
+
+## Discord Equivalent
+Discord Channel Categories - Collapsible channel groups that organize server layout and enable bulk permission management.
+
+## User Value Proposition
+- **Server Organization**: Group related channels together (e.g., "General", "Gaming", "Projects")
+- **Visual Clarity**: Reduce clutter in large servers with many channels
+- **Permission Management**: Set category-level permissions that cascade to child channels
+- **User Experience**: Collapse unused categories to focus on relevant content
+
+## Technical Complexity Estimate
+**P2** - Medium complexity
+
+## Implementation Sketch
+### Category System
+- Categories as special channel type with display-only properties
+- Drag-and-drop channel organization into categories
+- Category collapse/expand state per user
+- Inherited permissions from category to channels
+- Category-level muting and notification controls
+
+### Backend Changes
+```go
+type Category struct {
+    ID          string             `json:"id"`
+    Name        string             `json:"name"`
+    ServerID    string             `json:"server_id"`
+    Position    int                `json:"position"`
+    Permissions []PermissionOverwrite `json:"permission_overwrites"`
+    CreatedAt   time.Time          `json:"created_at"`
+}
+
+type Channel struct {
+    // ... existing fields ...
+    CategoryID  *string `json:"category_id,omitempty"`
+    Position    int     `json:"position"` // Position within category
+}
+```
+
+### Permission Inheritance
+- Category permissions apply to all child channels by default
+- Channel-specific overrides take precedence
+- Permission calculation: Server → Category → Channel → User/Role
+- Bulk permission updates through category management
+
+### Frontend Changes
+- Category headers in channel list with collapse/expand icons
+- Drag-and-drop interface for channel organization
+- Category creation and management modal
+- Visual indentation for channels within categories
+- Category-level context menus for bulk operations
+
+### Database Schema
+```sql
+CREATE TABLE categories (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    server_id UUID NOT NULL REFERENCES servers(id),
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+ALTER TABLE channels ADD COLUMN category_id UUID REFERENCES categories(id);
+ALTER TABLE channels ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE category_permissions (
+    id UUID PRIMARY KEY,
+    category_id UUID NOT NULL REFERENCES categories(id),
+    role_id UUID REFERENCES roles(id),
+    user_id UUID REFERENCES users(id),
+    permissions BIGINT NOT NULL,
+    allow BIGINT NOT NULL,
+    deny BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT category_permissions_target_check CHECK (
+        (role_id IS NOT NULL AND user_id IS NULL) OR
+        (role_id IS NULL AND user_id IS NOT NULL)
+    )
+);
+
+CREATE TABLE user_category_states (
+    user_id UUID NOT NULL REFERENCES users(id),
+    category_id UUID NOT NULL REFERENCES categories(id),
+    collapsed BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (user_id, category_id)
+);
+
+-- Indexes for performance
+CREATE INDEX idx_channels_category_position ON channels(category_id, position);
+CREATE INDEX idx_categories_server_position ON categories(server_id, position);
+```
+
+### Channel Ordering
+- Categories ordered by position
+- Channels within categories ordered by position
+- Channels without categories shown at top or bottom (configurable)
+- Drag-and-drop reordering updates positions
+
+## Dependencies
+- Permissions system must support inheritance
+- Channel management UI needs restructuring
+- Real-time updates for category state changes
+
+## Success Metrics
+- Percentage of servers using categories
+- Average number of categories per server
+- Reduction in uncategorized channels over time
+- User engagement with category collapse/expand features

--- a/PRDs/2026-03-29_stage-channels.md
+++ b/PRDs/2026-03-29_stage-channels.md
@@ -1,0 +1,55 @@
+# Stage Channels PRD
+
+## Feature Overview
+Stage channels for live audio broadcasts to large audiences with speaker management and audience controls.
+
+## Discord Equivalent
+Discord Stage Channels - Audio-focused channels where designated speakers can present to a listening audience.
+
+## User Value Proposition
+- **Community Building**: Host town halls, Q&A sessions, presentations, and live discussions
+- **Scalable Audio**: Support hundreds of listeners with minimal audio quality degradation
+- **Moderation Control**: Clear speaker/audience separation with raise-hand functionality
+- **Event Integration**: Natural fit with existing event system for scheduled broadcasts
+
+## Technical Complexity Estimate
+**P1** - Medium complexity
+
+## Implementation Sketch
+### Backend Changes
+- New channel type: `CHANNEL_TYPE_STAGE`
+- Stage-specific permissions: `MANAGE_STAGE`, `SPEAKER_PRIORITY`, `REQUEST_TO_SPEAK`
+- WebRTC modifications for broadcast-style audio (1-to-many optimization)
+- Stage state management: active speakers, audience, speaker queue
+- Integration with voice infrastructure but optimized for many listeners
+
+### Frontend Changes
+- Stage channel UI with speaker/audience distinction
+- Raise hand button and speaker request queue for moderators
+- Stage controls for moderators (invite/remove speakers, manage audience)
+- Visual indicators for speaking status and audio quality
+
+### Database Schema
+```sql
+ALTER TABLE channels ADD COLUMN stage_settings JSONB;
+-- stage_settings: {max_speakers: 10, auto_approve_speakers: false, ...}
+
+CREATE TABLE stage_participants (
+    user_id UUID NOT NULL,
+    channel_id UUID NOT NULL,
+    role VARCHAR(20) NOT NULL, -- 'speaker', 'audience', 'moderator'
+    requested_speaker_at TIMESTAMP,
+    PRIMARY KEY (user_id, channel_id)
+);
+```
+
+## Dependencies
+- Voice infrastructure must be operational
+- Permissions system for stage-specific roles
+- Event integration for scheduled stage events
+
+## Success Metrics
+- Stage channel creation rate
+- Average audience size per stage
+- Speaker engagement (requests to speak)
+- Audio quality metrics for large audiences

--- a/PRDs/2026-03-29_voice-messages.md
+++ b/PRDs/2026-03-29_voice-messages.md
@@ -1,0 +1,108 @@
+# Voice Messages PRD
+
+## Feature Overview
+Audio message recording and playback system for text channels, enabling quick voice communication without joining voice channels.
+
+## Discord Equivalent
+Discord Voice Messages - Short audio recordings sent as messages in text channels with waveform visualization and playback controls.
+
+## User Value Proposition
+- **Quick Communication**: Faster than typing for complex explanations
+- **Emotional Context**: Voice tone conveys emotion and nuance better than text
+- **Accessibility**: Easier for users with typing difficulties or language barriers
+- **Mobile-First**: Natural interaction model for mobile users
+
+## Technical Complexity Estimate
+**P1** - Medium complexity
+
+## Implementation Sketch
+### Voice Message Features
+- Record up to 5 minutes of audio per message
+- Waveform visualization during recording and playback
+- Playback speed controls (0.5x, 1x, 1.25x, 2x)
+- Voice message reactions and replies
+- Automatic transcription (optional)
+- Voice message search within transcriptions
+
+### Recording Interface
+- Push-to-talk or tap-to-record modes
+- Real-time waveform display during recording
+- Recording timer and remaining time indicator
+- Cancel/delete recording before sending
+- Preview playback before sending
+
+### Backend Changes
+```go
+type VoiceMessage struct {
+    ID           string    `json:"id"`
+    MessageID    string    `json:"message_id"`
+    Duration     int       `json:"duration"` // seconds
+    FileURL      string    `json:"file_url"`
+    Waveform     []int     `json:"waveform"` // amplitude data for visualization
+    Transcription *string  `json:"transcription,omitempty"`
+    FileSize     int64     `json:"file_size"`
+    CreatedAt    time.Time `json:"created_at"`
+}
+
+type Message struct {
+    // ... existing fields ...
+    VoiceMessage *VoiceMessage `json:"voice_message,omitempty"`
+}
+```
+
+### Audio Processing
+- Audio encoding: Opus codec for quality and compression
+- Waveform generation during upload processing
+- Audio normalization and noise reduction
+- File size limits based on server boost level
+- CDN storage for voice message files
+
+### Frontend Changes
+- Voice message recorder component with visual feedback
+- Waveform display component for playback
+- Audio player controls integrated into message layout
+- Mobile recording interface with hold-to-record gesture
+- Voice message transcript display (if available)
+
+### Database Schema
+```sql
+CREATE TABLE voice_messages (
+    id UUID PRIMARY KEY,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    file_path VARCHAR(500) NOT NULL,
+    file_size BIGINT NOT NULL,
+    duration_seconds INTEGER NOT NULL,
+    waveform JSONB, -- array of amplitude values
+    transcription TEXT,
+    transcription_confidence DECIMAL(3,2),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Index for voice message queries
+CREATE INDEX idx_voice_messages_message_id ON voice_messages(message_id);
+CREATE INDEX idx_voice_messages_transcription ON voice_messages USING gin(to_tsvector('english', transcription));
+```
+
+### Permissions & Settings
+- Server permission: `SEND_VOICE_MESSAGES`
+- User setting: auto-play voice messages
+- Channel setting: voice messages enabled/disabled
+- Mobile push notification settings for voice messages
+
+### Transcription Integration
+- Optional speech-to-text using AWS Transcribe or similar
+- Transcription confidence scoring
+- Manual transcription correction by sender
+- Search integration for voice message content
+
+## Dependencies
+- File upload infrastructure for audio files
+- Audio processing pipeline (encoding, waveform generation)
+- CDN/storage solution for voice message files
+- Optional: Speech-to-text service integration
+
+## Success Metrics
+- Voice message send rate vs text messages
+- Voice message completion rate (listened to end)
+- User adoption rate for voice messages
+- Average voice message duration

--- a/TASK_QUEUE.md
+++ b/TASK_QUEUE.md
@@ -23,3 +23,6 @@
 - [ ] **[P0]** Feature: Enhanced Server Discovery — Public server directory with search, categories, and recommendations for user acquisition
 - [ ] **[P0]** Feature: Scheduled Events — RSVP system, calendar integration, and event notifications for community building
 - [ ] **[P1]** Feature: Comprehensive Sticker System — Custom stickers, animated stickers, and premium sticker packs for engagement and monetization
+- [ ] **[P0]** Feature: Server Boosts & Premium Features — Subscription tiers with enhanced capabilities for monetization and sustainability
+- [ ] **[P0]** Feature: Stage Channels — Live audio broadcasts for large audiences with speaker management and community building
+- [ ] **[P1]** Feature: Advanced Message Search — Full-text search with filters for knowledge management in large communities

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -132,6 +132,12 @@ func (s *TemplateService) CreateTemplate(
 
 // serializeServer captures the current structure of a server for templating
 func (s *TemplateService) serializeServer(ctx context.Context, serverID uuid.UUID) (*models.TemplateSerializedData, error) {
+	// Get server settings first
+	server, err := s.serverRepo.GetByID(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get channels
 	channels, err := s.channelRepo.GetByServerID(ctx, serverID)
 	if err != nil {
@@ -201,7 +207,12 @@ func (s *TemplateService) serializeServer(ctx context.Context, serverID uuid.UUI
 	return &models.TemplateSerializedData{
 		Channels: templateChannels,
 		Roles:    templateRoles,
-		Settings: models.TemplateSettings{}, // TODO: add server settings to model if needed
+		Settings: models.TemplateSettings{
+			VerificationLevel:     server.VerificationLevel,
+			ExplicitContentFilter: server.ExplicitContentFilter,
+			DefaultNotifications:  server.DefaultNotifications,
+			AFKTimeout:            server.AFKTimeout,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
Populate TemplateSettings when creating a server template, including:
- VerificationLevel
- ExplicitContentFilter
- DefaultNotifications
- AFKTimeout

Previously these settings were lost when creating a template because
serializeServer returned an empty TemplateSettings{} struct.
