### PR TITLE
feat(frontend): implement jump-to-message scroll from pinned/search results

### DIFF
--- a/frontend/src/lib/components/MessageList.svelte
+++ b/frontend/src/lib/components/MessageList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, afterUpdate } from 'svelte';
-	import { messages, loadMessages, toggleReaction, addReaction } from '$lib/stores/messages';
+	import { messages, loadMessages, toggleReaction, addReaction, jumpToMessage } from '$lib/stores/messages';
 	import { currentChannel } from '$lib/stores/channels';
 	import { user } from '$lib/stores/auth';
 	import { currentServer } from '$lib/stores/servers';
@@ -47,6 +47,25 @@
 			messageContainer.scrollTop = messageContainer.scrollHeight;
 		}
 	});
+
+	// Handle jump to message from pinned panel or search results
+	function scrollToMessage(messageId: string) {
+		if (!messageContainer) return;
+		const el = messageContainer.querySelector(`[data-message-id="${messageId}"]`);
+		if (el) {
+			el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+			// Flash highlight
+			el.classList.add('message-highlight');
+			setTimeout(() => el.classList.remove('message-highlight'), 1500);
+			// Clear the jump target after scrolling
+			jumpToMessage.clear();
+		}
+	}
+
+	// React to jumpToMessage store changes
+	$: if ($jumpToMessage.messageId && $jumpToMessage.channelId === $currentChannel?.id) {
+		scrollToMessage($jumpToMessage.messageId);
+	}
 
 	function formatDate(date: string) {
 		const d = new Date(date);
@@ -234,5 +253,15 @@
 
 	.message-list-container::-webkit-scrollbar-thumb:hover {
 		background: #232428;
+	}
+
+	/* Highlight animation for jump-to-message */
+	.message-highlight {
+		animation: highlight-flash 1.5s ease-out;
+	}
+	
+	@keyframes highlight-flash {
+		0% { background-color: rgba(239, 68, 68, 0.3); }
+		100% { background-color: transparent; }
 	}
 </style>

--- a/frontend/src/lib/stores/index.ts
+++ b/frontend/src/lib/stores/index.ts
@@ -2,7 +2,7 @@ export { auth, isAuthenticated, user, user as currentUser } from './auth';
 export { gateway, gatewayState, onGatewayEvent } from './gateway';
 export { servers, currentServer, currentServer as activeServer } from './servers';
 export { channels, currentChannel, currentChannel as activeChannel, loadServerChannels } from './channels';
-export { messages } from './messages';
+export { messages, jumpToMessage } from './messages';
 export { settings, isSettingsOpen, appSettings, currentTheme } from './settings';
 export { theme, themeChoice, resolvedTheme, type ThemeChoice, type ResolvedTheme } from './theme';
 export { typingStore, formatTypingText, setCurrentUserId } from './typing';

--- a/frontend/src/lib/stores/messages.ts
+++ b/frontend/src/lib/stores/messages.ts
@@ -557,3 +557,34 @@ function getCurrentUserId(): string {
 		return '';
 	}
 }
+
+// Jump to message store - holds the target message to scroll to
+interface JumpToMessageState {
+	channelId: string | null;
+	messageId: string | null;
+}
+
+function createJumpToMessageStore() {
+	const { subscribe, set } = writable<JumpToMessageState>({
+		channelId: null,
+		messageId: null
+	});
+
+	return {
+		subscribe,
+		/**
+		 * Jump to a specific message in a channel
+		 */
+		jump(channelId: string, messageId: string) {
+			set({ channelId, messageId });
+		},
+		/**
+		 * Clear the jump target
+		 */
+		clear() {
+			set({ channelId: null, messageId: null });
+		}
+	};
+}
+
+export const jumpToMessage = createJumpToMessageStore();

--- a/frontend/src/routes/channels/+layout.svelte
+++ b/frontend/src/routes/channels/+layout.svelte
@@ -13,6 +13,7 @@
 	import { pinnedMessagesStore, pinnedMessagesOpen } from '$lib/stores/pinnedMessages';
 	import { searchStore, isSearchOpen } from '$lib/stores/search';
 	import { splitViewStore, splitViewEnabled, canAddSplitPanel } from '$lib/stores/splitView';
+	import { jumpToMessage } from '$lib/stores/messages';
 	import ServerList from '$lib/components/ServerList.svelte';
 	import ChannelList from '$lib/components/ChannelList.svelte';
 	import MemberList from '$lib/components/MemberList.svelte';
@@ -173,10 +174,8 @@
 		// Close the pinned messages panel
 		pinnedMessagesStore.close();
 		
-		// TODO: Scroll to message in MessageList
-		// For now, we just close the panel - scrolling to message would require
-		// additional coordination with the MessageList component
-		console.log('Jump to message:', event.detail.messageId);
+		// Scroll to message in MessageList via the jumpToMessage store
+		jumpToMessage.jump(event.detail.channelId, event.detail.messageId);
 	}
 </script>
 


### PR DESCRIPTION
- Add jumpToMessage store to coordinate scroll-to-message between layout and MessageList
- MessageList subscribes to jumpToMessage store and scrolls to target message with highlight animation
- Layout's handleJumpToMessage now uses the store instead of just logging
- Works for both pinned messages panel and search results jump-to actions

Fixes P3 TODO from TASK_QUEUE.md: Scroll to message in MessageList
