### PR TITLE
fix(discovery): link server verification from discoverable_servers table

### DIFF
--- a/backend/internal/database/postgres/discovery_repo.go
+++ b/backend/internal/database/postgres/discovery_repo.go
@@ -204,9 +204,11 @@ func (r *DiscoveryRepository) SearchServers(ctx context.Context, filters *models
 			l.member_count_snapshot, l.online_count_snapshot, l.weekly_growth_rate,
 			l.engagement_score, l.region, l.language, l.created_at,
 			s.name, s.icon_url, s.banner_url, s.description,
-			c.name as category_name, c.slug as category_slug
+			c.name as category_name, c.slug as category_slug,
+			COALESCE(ds.is_verified, false) as is_verified
 		FROM server_discovery_listings l
 		JOIN servers s ON s.id = l.server_id
+		LEFT JOIN discoverable_servers ds ON ds.server_id = l.server_id
 		LEFT JOIN server_discovery_listing_categories lc ON lc.listing_id = l.id
 		LEFT JOIN server_discovery_categories c ON c.id = lc.category_id AND lc.category_id = (
 			SELECT lc2.category_id FROM server_discovery_listing_categories lc2 WHERE lc2.listing_id = l.id ORDER BY c.sort_order LIMIT 1
@@ -232,12 +234,13 @@ func (r *DiscoveryRepository) SearchServers(ctx context.Context, filters *models
 		var categoryName, categorySlug sql.NullString
 		var region, iconURL, bannerURL, description sql.NullString
 
+		var isVerified bool
 		err := rows.Scan(
 			&sr.ID, &sr.ServerID, &sr.ShortDescription, &sr.IsFeatured,
 			&sr.MemberCountSnapshot, &sr.OnlineCountSnapshot, &sr.WeeklyGrowthRate,
 			&sr.EngagementScore, &region, &sr.Language, &sr.CreatedAt,
 			&s.Name, &iconURL, &bannerURL, &description,
-			&categoryName, &categorySlug,
+			&categoryName, &categorySlug, &isVerified,
 		)
 		if err != nil {
 			return nil, 0, err
@@ -260,7 +263,7 @@ func (r *DiscoveryRepository) SearchServers(ctx context.Context, filters *models
 		sr.Name = s.Name
 		sr.MemberCount = sr.MemberCountSnapshot
 		sr.OnlineCount = sr.OnlineCountSnapshot
-		sr.IsVerified = false // TODO: Link to server verification
+		sr.IsVerified = isVerified
 
 		if categorySlug.Valid {
 			sr.Category = models.ServerCategory(categorySlug.String)

--- a/frontend/src/routes/guild-discovery/+page.svelte
+++ b/frontend/src/routes/guild-discovery/+page.svelte
@@ -60,61 +60,61 @@
 		{
 			id: '1', name: 'Hearth Official',
 			description: 'The official Hearth community server. Get help, share feedback, and connect with other users.',
-			icon_url: null, banner_url: null, member_count: 12543, category: 'technology',
+			icon_url: undefined, banner_url: undefined, member_count: 12543, category: 'technology',
 			tags: ['open-source', 'community', 'support'], is_featured: true
 		},
 		{
 			id: '2', name: 'Pixel Warriors',
 			description: 'A friendly gaming community for casual and competitive players alike.',
-			icon_url: null, banner_url: null, member_count: 8932, category: 'gaming',
+			icon_url: undefined, banner_url: undefined, member_count: 8932, category: 'gaming',
 			tags: ['gaming', 'fun', 'events'], is_featured: true
 		},
 		{
 			id: '3', name: 'Synthwave Lounge',
 			description: 'Share and discover synthwave, vaporwave, and retro music.',
-			icon_url: null, banner_url: null, member_count: 5621, category: 'music',
+			icon_url: undefined, banner_url: undefined, member_count: 5621, category: 'music',
 			tags: ['music', 'artists', 'discovery'], is_featured: true
 		},
 		{
 			id: '4', name: 'Code Crafters',
 			description: 'Programming discussions, code reviews, and learning resources.',
-			icon_url: null, banner_url: null, member_count: 15234, category: 'technology',
+			icon_url: undefined, banner_url: undefined, member_count: 15234, category: 'technology',
 			tags: ['programming', 'learning', 'help'], is_featured: true
 		},
 		{
 			id: '5', name: 'Digital Artists Hub',
 			description: 'A creative space for digital artists to share work and get feedback.',
-			icon_url: null, banner_url: null, member_count: 3421, category: 'art',
+			icon_url: undefined, banner_url: undefined, member_count: 3421, category: 'art',
 			tags: ['art', 'design', 'feedback'], is_featured: false
 		},
 		{
 			id: '6', name: 'Study Buddies',
 			description: 'Join study sessions, share resources, and motivate each other.',
-			icon_url: null, banner_url: null, member_count: 2156, category: 'education',
+			icon_url: undefined, banner_url: undefined, member_count: 2156, category: 'education',
 			tags: ['study', 'motivation', 'productivity'], is_featured: false
 		},
 		{
 			id: '7', name: 'Space Explorers',
 			description: 'Discuss astronomy, space missions, and the mysteries of the universe.',
-			icon_url: null, banner_url: null, member_count: 8765, category: 'science',
+			icon_url: undefined, banner_url: undefined, member_count: 8765, category: 'science',
 			tags: ['space', 'science', 'discussion'], is_featured: true
 		},
 		{
 			id: '8', name: 'Movie Night',
 			description: 'Watch parties, movie discussions, and recommendations.',
-			icon_url: null, banner_url: null, member_count: 4521, category: 'entertainment',
+			icon_url: undefined, banner_url: undefined, member_count: 4521, category: 'entertainment',
 			tags: ['movies', 'tv', 'watch-party'], is_featured: false
 		},
 		{
 			id: '9', name: 'Chill & Chat',
 			description: 'A relaxed place to hang out and make new friends.',
-			icon_url: null, banner_url: null, member_count: 9876, category: 'social',
+			icon_url: undefined, banner_url: undefined, member_count: 9876, category: 'social',
 			tags: ['social', 'friends', 'chill'], is_featured: false
 		},
 		{
 			id: '10', name: 'Sports Central',
 			description: 'Discuss your favorite sports, teams, and athletes.',
-			icon_url: null, banner_url: null, member_count: 6789, category: 'sports',
+			icon_url: undefined, banner_url: undefined, member_count: 6789, category: 'sports',
 			tags: ['sports', 'discussion', 'news'], is_featured: false
 		},
 	];
@@ -363,7 +363,7 @@
 		const matchesSearch = !searchQuery || 
 			server.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
 			(server.description || '').toLowerCase().includes(searchQuery.toLowerCase()) ||
-			server.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
+			server.tags?.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
 		return matchesCategory && matchesSearch;
 	});
 


### PR DESCRIPTION
Previously, sr.IsVerified was hardcoded to false in SearchServers().
Now we LEFT JOIN with discoverable_servers table to get the actual
verification status, linking the discovery listings to the newer
public server directory verification system.
