### PR TITLE
fix(a11y): add tabindex to soundboard picker dialog

### DIFF
--- a/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
+++ b/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
@@ -265,6 +265,7 @@
 		role="dialog" 
 		aria-label="Soundboard picker" 
 		aria-modal="true"
+		tabindex="-1"
 		on:keydown={handleKeydown}
 	>
 		<!-- Header -->


### PR DESCRIPTION
Add tabindex=-1 to the soundboard picker dialog element to fix
accessibility warning about interactive elements with role='dialog'
requiring a tabindex value.
