### PR TITLE
security: fix G304 path traversal in local storage via os.Root (Go 1.24+)

### DIFF
--- a/backend/internal/storage/local_compat.go
+++ b/backend/internal/storage/local_compat.go
@@ -1,4 +1,4 @@
-//go:build go1.24
+//go:build !go1.24
 
 package storage
 
@@ -14,15 +14,13 @@ import (
 )
 
 // LocalBackend implements StorageBackend for local filesystem.
-// File I/O is scoped under basePath using os.Root (Go 1.24+) for
-// kernel-level enforcement against path traversal and symlink escapes.
+// This is the Go < 1.24 fallback using manual path validation + prefix checks.
 type LocalBackend struct {
 	basePath  string
 	publicURL string
-	root      *os.Root
 }
 
-// validatePath performs a fast pre-check before any file operation.
+// validatePath ensures the path doesn't escape the base directory.
 func (b *LocalBackend) validatePath(path string) error {
 	if path == "" || filepath.IsAbs(path) {
 		return fmt.Errorf("invalid path: must be a relative, non-empty path")
@@ -31,87 +29,70 @@ func (b *LocalBackend) validatePath(path string) error {
 	if strings.Contains(cleanPath, "..") {
 		return fmt.Errorf("invalid path: contains parent directory reference")
 	}
+	fullPath := filepath.Join(b.basePath, cleanPath)
+	if !strings.HasPrefix(fullPath, filepath.Clean(b.basePath)+string(os.PathSeparator)) {
+		return fmt.Errorf("invalid path: outside storage directory")
+	}
 	return nil
 }
 
-// NewLocalBackend creates a new local filesystem storage backend using os.Root
-// (Go 1.24+) for kernel-level path scoping.
+// NewLocalBackend creates a new local filesystem storage backend.
 func NewLocalBackend(basePath, publicURL string) (*LocalBackend, error) {
 	if err := os.MkdirAll(basePath, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create storage directory: %w", err)
 	}
-	root, err := os.OpenRoot(basePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create scoped root: %w", err)
-	}
-	return &LocalBackend{basePath: basePath, publicURL: publicURL, root: root}, nil
+	return &LocalBackend{basePath: basePath, publicURL: publicURL}, nil
 }
 
-// ensureDirs creates each directory component of relPath via root.Mkdir.
-func (b *LocalBackend) ensureDirs(relPath string) error {
-	relPath = filepath.Clean(relPath)
-	dir := filepath.Dir(relPath)
-	if dir == "." || dir == "" {
-		return nil
-	}
-	parts := strings.Split(dir, string(os.PathSeparator))
-	for i := range parts {
-		segment := strings.Join(parts[:i+1], string(os.PathSeparator))
-		if segment == "" {
-			continue
-		}
-		if err := b.root.Mkdir(segment, 0750); err != nil && !os.IsExist(err) {
-			return fmt.Errorf("failed to create directory %s: %w", segment, err)
-		}
-	}
-	return nil
-}
-
-// Upload saves a file scoped to basePath via root.Create.
+// Upload saves a file to the local filesystem.
 func (b *LocalBackend) Upload(ctx context.Context, path string, file io.Reader, contentType string, size int64) (retPath string, retErr error) {
 	if err := b.validatePath(path); err != nil {
 		return "", err
 	}
 	cleanPath := filepath.Clean(path)
-	if err := b.ensureDirs(cleanPath); err != nil {
-		return "", err
+	fullPath := filepath.Join(b.basePath, cleanPath)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
 	}
-	f, err := b.root.Create(cleanPath)
+	dst, err := os.Create(fullPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create file: %w", err)
 	}
 	defer func() {
-		if closeErr := f.Close(); closeErr != nil && retErr == nil {
-			retErr = fmt.Errorf("failed to close file: %w", closeErr)
+		if err := dst.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close file: %w", err)
 		}
 	}()
-	if _, err := io.Copy(f, file); err != nil {
-		if removeErr := b.root.Remove(cleanPath); removeErr != nil {
-			log.Printf("Failed to remove partial file %s: %v", cleanPath, removeErr)
+	if _, err := io.Copy(dst, file); err != nil {
+		if removeErr := os.Remove(fullPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Printf("Failed to remove partial file %s: %v", fullPath, removeErr)
 		}
 		return "", fmt.Errorf("failed to write file: %w", err)
 	}
 	return b.GetURL(path), nil
 }
 
-// Download retrieves a file scoped to basePath via root.Open.
+// Download retrieves a file from the local filesystem.
 func (b *LocalBackend) Download(ctx context.Context, path string) (io.ReadCloser, error) {
 	if err := b.validatePath(path); err != nil {
 		return nil, err
 	}
-	f, err := b.root.Open(filepath.Clean(path))
+	fullPath := filepath.Join(b.basePath, filepath.Clean(path))
+	f, err := os.Open(fullPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	return f, nil
 }
 
-// Delete removes a file scoped to basePath via root.Remove.
+// Delete removes a file from the local filesystem.
 func (b *LocalBackend) Delete(ctx context.Context, path string) error {
 	if err := b.validatePath(path); err != nil {
 		return err
 	}
-	if err := b.root.Remove(filepath.Clean(path)); err != nil && !os.IsNotExist(err) {
+	fullPath := filepath.Join(b.basePath, filepath.Clean(path))
+	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
 	return nil

--- a/backend/internal/storage/local_test.go
+++ b/backend/internal/storage/local_test.go
@@ -71,8 +71,8 @@ func TestLocalBackend_validatePath(t *testing.T) {
 		{
 			name:    "absolute path that would escape",
 			path:    "/etc/passwd",
-			wantErr: false,
-			reason:  "absolute paths get joined and stay within bounds",
+			wantErr: true,
+			reason:  "absolute paths are rejected to prevent os.Root escape",
 		},
 	}
 


### PR DESCRIPTION
Closes G304 (CWE-22) — File Path Traversal in Local Storage.

Problem:
- backend/internal/storage/local.go used os.Open/Create with paths built via
  filepath.Join, with only manual prefix checks as traversal protection.
- A symlink placed inside the storage directory could point outside it
  (e.g. storage/evilsymlink -> /etc/passwd), bypassing manual checks.
  os.Root (Go 1.24+) provides kernel-level enforcement via openat syscalls
  that prevents ALL escapes including via symlinks.

Fix:
- backend/internal/storage/local.go: reimplemented Upload/Download/Delete to
  use root.Open, root.Create, root.Remove, root.Mkdir — all confined to the
  basePath via os.OpenRoot. Added validatePath as a fast pre-check that
  rejects absolute paths and paths containing '..'.
- backend/internal/storage/local_compat.go: Go < 1.24 fallback using the
  original manual prefix-check approach (os.Create/os.Open with validatePath).
  Both implementations expose the same LocalBackend interface.
- backend/internal/storage/local_test.go: updated one test case that
  expected absolute paths to pass validatePath — they now correctly return
  error (security hardening; absolute paths must not reach os.Root.Open).

Build: requires Go 1.24+ for the primary implementation (project targets 1.25.8).
Compat layer provides working fallback for Go < 1.24.

Author: Greg Hendrickson <greg@hndrx.co>
