### PR TITLE
security: fix G118 goroutine context leak in maybeAutoCreateThread

### DIFF
--- a/backend/internal/services/message_service.go
+++ b/backend/internal/services/message_service.go
@@ -315,7 +315,7 @@ func (s *MessageService) SendMessage(ctx context.Context, authorID uuid.UUID, ch
 
 	// Auto-create thread when a message gets 3+ replies
 	if replyTo != nil && s.threadService != nil {
-		go s.maybeAutoCreateThread(context.Background(), channelID, *replyTo, authorID)
+		go s.maybeAutoCreateThread(ctx, channelID, *replyTo, authorID)
 	}
 
 	return message, nil


### PR DESCRIPTION
Replace context.Background() with request-scoped ctx in goroutine spawned
from SendMessage. This ensures request cancellation/timeouts propagate
to the auto-thread-creation logic, preventing orphaned work after client
disconnect.

Closes G118 (CWE-400/CWE-554)
