### PR TITLE
fix(api): correct route param names in thread auto-archive tests

### DIFF
--- a/backend/internal/api/handlers/thread_auto_archive_test.go
+++ b/backend/internal/api/handlers/thread_auto_archive_test.go
@@ -97,17 +97,17 @@ func setupThreadAutoArchiveTestApp(handler *ThreadAutoArchiveHandler) *fiber.App
 	})
 
 	// Server auto-archive settings routes
-	app.Get("/servers/:server_id/auto-archive", handler.GetServerAutoArchiveSettings)
-	app.Patch("/servers/:server_id/auto-archive", handler.UpdateServerAutoArchiveSettings)
-	app.Get("/servers/:server_id/auto-archive/stats", handler.GetServerAutoArchiveStats)
+	app.Get("/servers/:id/auto-archive", handler.GetServerAutoArchiveSettings)
+	app.Patch("/servers/:id/auto-archive", handler.UpdateServerAutoArchiveSettings)
+	app.Get("/servers/:id/auto-archive/stats", handler.GetServerAutoArchiveStats)
 
 	// Channel auto-archive override routes
-	app.Get("/channels/:channel_id/auto-archive", handler.GetChannelAutoArchiveOverride)
-	app.Put("/channels/:channel_id/auto-archive", handler.SetChannelAutoArchiveOverride)
-	app.Delete("/channels/:channel_id/auto-archive", handler.DeleteChannelAutoArchiveOverride)
+	app.Get("/channels/:id/auto-archive", handler.GetChannelAutoArchiveOverride)
+	app.Put("/channels/:id/auto-archive", handler.SetChannelAutoArchiveOverride)
+	app.Delete("/channels/:id/auto-archive", handler.DeleteChannelAutoArchiveOverride)
 
 	// Thread auto-archive status routes
-	app.Get("/threads/:thread_id/auto-archive", handler.GetThreadAutoArchiveStatus)
+	app.Get("/threads/:id/auto-archive", handler.GetThreadAutoArchiveStatus)
 
 	return app
 }


### PR DESCRIPTION
The test setup used :server_id, :channel_id, :thread_id params but
the handler methods expect :id. This caused all 9 thread auto-archive
handler tests to fail with 400 Bad Request instead of exercising the
mock service.

Change route params to :id to match handler c.Params("id") calls.
