### PR TITLE
test(api): add ComponentHandler tests and refactor to use interfaces

### DIFF
--- a/PRDs/2026-03-31_advanced-forum-channels.md
+++ b/PRDs/2026-03-31_advanced-forum-channels.md
@@ -1,0 +1,94 @@
+# Advanced Forum Channels
+
+## Overview
+Implement comprehensive forum channel functionality with post creation, tagging, sorting, and moderation features to support community discussions and knowledge management.
+
+## Discord Equivalent
+Discord's Forum Channels with post creation, tags, sorting options, solved/answered states, and structured community discussions.
+
+## User Value Proposition
+- **Organized Discussions**: Structured discussions with topics and replies
+- **Knowledge Base**: Searchable repository of community knowledge
+- **Reduced Noise**: Keeps discussions organized vs scattered in text channels
+- **Moderation**: Better tools for managing community discussions
+- **Discoverability**: Tags and search make content findable
+
+## Technical Complexity: P1
+- **Post/Thread Structure**: Forum posts as special thread types
+- **Tag System**: Multi-tag filtering and organization
+- **Sort/Filter Options**: Multiple sorting and filtering algorithms
+- **Search Integration**: Full-text search across forum content
+- **Moderation Tools**: Forum-specific moderation features
+
+## Implementation Sketch
+```
+Backend:
+- forum_posts table extending thread structure
+- forum_post_tags for tagging system
+- post_reactions and solved_status tracking
+- Advanced search indexing for forum content
+- Forum-specific permission system
+
+Database Schema:
+- forum_channels (extends channels)
+- forum_posts (extends threads with post-specific fields)
+- forum_tags (server-defined tags)
+- forum_post_tags (many-to-many relationship)
+- forum_sort_preferences (user sorting preferences)
+
+Frontend:
+- Forum channel view with post grid/list
+- Post creation modal with tag selection
+- Advanced filtering and sorting UI
+- Post detail view with threaded replies
+- Tag management interface for moderators
+```
+
+## Forum Features
+```
+Post Management:
+- Create posts with title, content, and tags
+- Edit/delete posts with moderation controls
+- Pin important posts to top
+- Mark posts as solved/answered
+- Post archiving and locking
+
+Sorting Options:
+- Latest Activity (default)
+- Creation Date
+- Most Reactions
+- Solved/Unsolved
+- Tag-based filtering
+
+Tagging System:
+- Server-defined tag categories
+- Multi-select tag filtering
+- Tag colors and emoji icons
+- Required vs optional tags
+- Tag-based permissions
+```
+
+## Dependencies
+- Thread system (✓ implemented)
+- Forum tags (✓ partially implemented)
+- Search system (✓ implemented)
+- Channel system (✓ implemented)
+- Permission system (needs advanced permissions)
+
+## Forum-Specific Permissions
+- CREATE_FORUM_POSTS
+- MANAGE_FORUM_POSTS
+- CREATE_FORUM_TAGS
+- MANAGE_FORUM_TAGS
+- PIN_FORUM_POSTS
+- LOCK_FORUM_POSTS
+
+## Success Metrics
+- Forum channel creation rate
+- Posts per forum channel (target: >50 posts/channel/month)
+- Tag usage adoption
+- Search queries in forum channels
+- Post resolution rate (solved/answered)
+
+## Priority Justification
+Forum channels are essential for knowledge-based communities and provide structured discussion capabilities that text channels cannot match. Many Discord communities rely heavily on forums for FAQ, support, and organized discussions.

--- a/PRDs/2026-03-31_advanced-permissions-system.md
+++ b/PRDs/2026-03-31_advanced-permissions-system.md
@@ -1,0 +1,77 @@
+# Advanced Permissions System
+
+## Overview
+Implement Discord's advanced permission system with role hierarchies, channel overrides, and fine-grained permission controls for comprehensive server management.
+
+## Discord Equivalent
+Discord's permission system with role hierarchies, channel-specific overrides, permission inheritance, and bitfield-based permission flags.
+
+## User Value Proposition
+- **Server Control**: Granular control over who can do what in each channel
+- **Moderation**: Enable complex moderation hierarchies and workflows
+- **Privacy**: Create private channels and categories with specific access
+- **Scalability**: Manage permissions efficiently in large servers
+- **Flexibility**: Support diverse server structures and use cases
+
+## Technical Complexity: P1
+- **Permission Inheritance**: Complex hierarchy resolution between roles and channels
+- **Bitfield Operations**: Efficient permission checking and storage
+- **Override System**: Channel-specific permission overrides
+- **Performance**: Fast permission checking for real-time operations
+
+## Implementation Sketch
+```
+Backend:
+- Permission bitfield system (64-bit flags)
+- Role hierarchy enforcement
+- Channel override resolution algorithm
+- Permission inheritance calculator
+- Audit logging for permission changes
+
+Database Schema:
+- role_permissions table with bitfield columns
+- channel_permission_overrides table
+- permission_hierarchy tracking
+- audit_log entries for permission changes
+
+Permission Flags:
+- VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS
+- MANAGE_MESSAGES, MANAGE_CHANNELS, MANAGE_ROLES
+- KICK_MEMBERS, BAN_MEMBERS, ADMINISTRATOR
+- VOICE permissions (CONNECT, SPEAK, STREAM)
+- Advanced permissions (MANAGE_WEBHOOKS, etc.)
+```
+
+## Permission Resolution Algorithm
+```
+1. Start with @everyone role permissions
+2. Apply all user's role permissions (OR operation)
+3. Apply channel-specific role overrides
+4. Apply user-specific channel overrides (highest priority)
+5. Check for ADMINISTRATOR flag (bypasses all checks)
+6. Return final permission set
+```
+
+## Dependencies
+- Role system (✓ implemented)
+- Channel system (✓ implemented)
+- User management (✓ implemented)
+- Audit logging (✓ implemented)
+
+## API Changes
+```
+GET /api/v1/guilds/{id}/roles/{role_id}/permissions
+PATCH /api/v1/guilds/{id}/roles/{role_id}/permissions
+GET /api/v1/channels/{id}/permissions/{target_id}
+PUT /api/v1/channels/{id}/permissions/{target_id}
+GET /api/v1/users/@me/permissions/{guild_id}
+```
+
+## Success Metrics
+- Permission check performance (<5ms average)
+- Successful migration from basic to advanced permissions
+- Reduction in permission-related support tickets
+- Server admin satisfaction with permission controls
+
+## Priority Justification
+Advanced permissions are fundamental for server management and essential for competing with Discord's flexibility. Many server structures require fine-grained permission control.

--- a/PRDs/2026-03-31_bot-api-developer-platform.md
+++ b/PRDs/2026-03-31_bot-api-developer-platform.md
@@ -1,0 +1,71 @@
+# Bot API and Developer Platform
+
+## Overview
+Create a comprehensive developer platform with Bot API, OAuth2 applications, and developer tools to enable third-party bot development and integrations.
+
+## Discord Equivalent
+Discord's Developer Portal with Bot API, OAuth2, slash commands, and application management - the foundation of Discord's rich bot ecosystem.
+
+## User Value Proposition
+- **Ecosystem Growth**: Enables third-party developers to build bots and integrations
+- **Server Utility**: Allows server owners to add custom functionality via bots
+- **Developer Revenue**: Platform for bot developers to monetize their applications
+- **Feature Extension**: Community can build features faster than core team
+- **Competitive Necessity**: Essential for retaining users who rely on Discord bots
+
+## Technical Complexity: P0
+- **Bot Authentication**: JWT-based bot tokens and OAuth2 flows
+- **API Gateway**: Rate limiting, request validation, and routing
+- **Permission System**: Fine-grained bot permissions and scopes
+- **Developer Tools**: SDKs, documentation, and testing environments
+- **Application Management**: Bot creation, token management, verification
+
+## Implementation Sketch
+```
+Backend:
+- REST API endpoints for all bot operations
+- WebSocket gateway for real-time events
+- OAuth2 server implementation for bot authorization
+- Application management APIs
+- Bot verification and approval system
+
+Developer Portal:
+- Application creation and management dashboard
+- API documentation and interactive testing
+- Bot metrics and analytics
+- Bot store/directory for discovery
+- Developer support and resources
+
+Bot Features:
+- Slash commands framework
+- Message components (buttons, dropdowns)
+- Webhook integration
+- Custom emoji access
+- Server management APIs
+```
+
+## Dependencies
+- Core API infrastructure (✓ implemented)
+- Permission system (✓ implemented)
+- OAuth2 provider (✓ implemented)
+- Component handler system (✓ implemented)
+- Slash commands (✓ implemented)
+
+## API Endpoints (Sample)
+```
+POST /api/v1/applications - Create bot application
+GET /api/v1/channels/{id}/messages - Get channel messages
+POST /api/v1/channels/{id}/messages - Send message
+GET /api/v1/guilds/{id} - Get server info
+POST /api/v1/interactions/{id}/callback - Respond to interaction
+GET /api/v1/users/@me - Get bot user info
+```
+
+## Success Metrics
+- Number of registered bot applications (target: 1000+ in 6 months)
+- API request volume (target: 10M+ requests/month)
+- Developer adoption rate (target: 500+ active developers)
+- Bot directory listings (target: 100+ verified bots)
+
+## Priority Justification
+Without a bot API, Hearth cannot replicate the utility and customization that Discord users expect. This is blocking for user migration and ecosystem growth.

--- a/PRDs/2026-03-31_cross-server-features.md
+++ b/PRDs/2026-03-31_cross-server-features.md
@@ -1,0 +1,83 @@
+# Cross-Server Features
+
+## Overview
+Enable cross-server functionality including emoji usage from other servers, server following, and cross-server user interactions to create a connected ecosystem.
+
+## Discord Equivalent
+Discord's cross-server emoji usage (for Nitro users), server following, and cross-server friend systems that create connectivity between different communities.
+
+## User Value Proposition
+- **Premium Value**: Cross-server emoji usage as a premium feature incentive
+- **Community Connection**: Users can stay connected across multiple servers
+- **Content Discovery**: Server following enables content discovery across communities
+- **User Retention**: Reduces friction when users want to engage across servers
+- **Network Effects**: Creates stronger ecosystem with interconnected communities
+
+## Technical Complexity: P1
+- **Emoji Federation**: Cross-server emoji resolution and caching
+- **Server Following**: Channel content syndication across servers
+- **Permission Management**: Cross-server interaction permissions
+- **Caching Strategy**: Efficient cross-server data caching
+- **Privacy Controls**: User control over cross-server visibility
+
+## Implementation Sketch
+```
+Backend:
+- Cross-server emoji API with permission validation
+- Server following service with content syndication
+- Cross-server notification system
+- Federation cache layer for performance
+- Privacy control APIs
+
+Database:
+- server_follows table (user -> server relationships)
+- cross_server_emoji_permissions (server emoji sharing settings)
+- federated_cache for cross-server data
+- user_cross_server_settings for privacy controls
+
+Features:
+- Cross-server emoji picker (premium users)
+- Server following feed
+- Cross-server friend presence
+- Server recommendation based on follows
+```
+
+## Cross-Server Emoji System
+```
+1. Server owners can enable/disable emoji sharing
+2. Premium users can use emojis from servers they're in
+3. Emoji resolution checks permissions in real-time
+4. Emoji cache updated when permissions change
+5. Fallback to server emojis for non-premium users
+```
+
+## Server Following
+```
+1. Users can follow public servers they're not in
+2. Followed server updates appear in activity feed
+3. Public announcements from followed servers
+4. Server event notifications for followers
+5. Trending content from followed servers
+```
+
+## Dependencies
+- Premium subscription system (✓ implemented)
+- Emoji system (✓ implemented)
+- Server discovery (✓ implemented)
+- Notification system (✓ implemented)
+- Caching infrastructure (✓ implemented)
+
+## Privacy Controls
+- Users can disable cross-server presence
+- Servers can opt out of being followable
+- Fine-grained controls over what data is shared
+- Block/unblock cross-server interactions
+
+## Success Metrics
+- Cross-server emoji usage rate (premium users)
+- Server following adoption (target: 30% of users follow >1 server)
+- Cross-server engagement metrics
+- Premium subscription conversion from cross-server features
+
+## Priority Justification
+Cross-server features create network effects and premium value propositions. They're essential for building a cohesive ecosystem and reducing user churn when they need to engage across multiple communities.

--- a/PRDs/2026-03-31_live-video-streaming.md
+++ b/PRDs/2026-03-31_live-video-streaming.md
@@ -1,0 +1,53 @@
+# Live Video Streaming
+
+## Overview
+Implement live video streaming capabilities that allow users to broadcast video content to large audiences within voice channels, similar to Discord's Go Live feature.
+
+## Discord Equivalent
+Discord's "Go Live" feature - users can stream games, applications, or their desktop to voice channel participants with high-quality video and audio.
+
+## User Value Proposition
+- **Content Creation**: Enables streamers to broadcast to their community directly within Hearth
+- **Community Building**: Creates shared viewing experiences and social interaction
+- **Competitive Parity**: Essential feature for users migrating from Discord
+- **Engagement**: Increases time spent in voice channels and server activity
+
+## Technical Complexity: P1
+- **Video Encoding/Decoding**: H.264/VP8 streaming implementation
+- **Bandwidth Management**: Adaptive bitrate streaming for different connection qualities
+- **Scalability**: Support for 50+ concurrent viewers per stream
+- **Integration**: Works within existing voice channel infrastructure
+
+## Implementation Sketch
+```
+Backend:
+- Extend voice infrastructure with video streaming capabilities
+- Add stream discovery and viewer management APIs
+- Implement bandwidth throttling and quality adaptation
+- Add stream recording/replay functionality
+
+Frontend:
+- Stream preview window with quality controls
+- Viewer grid with chat overlay
+- Stream discovery UI within voice channels
+- Mobile streaming support
+
+Database:
+- Stream metadata, viewer counts, and analytics
+- Stream permissions and moderation settings
+```
+
+## Dependencies
+- Voice channel infrastructure (✓ implemented)
+- WebRTC implementation (✓ implemented)
+- Video codec support in backend
+- Enhanced bandwidth monitoring
+
+## Success Metrics
+- Stream adoption rate (target: 15% of voice users streaming monthly)
+- Viewer engagement (average watch time >5 minutes)
+- Stream quality satisfaction scores
+- Concurrent viewer limits achieved
+
+## Priority Justification
+Live streaming is a signature Discord feature that drives significant user engagement and retention. Without this, Hearth cannot compete effectively for content creator communities.

--- a/PRDs/2026-03-31_message-reactions-system.md
+++ b/PRDs/2026-03-31_message-reactions-system.md
@@ -1,0 +1,100 @@
+# Message Reactions System
+
+## Overview
+Implement comprehensive message reaction functionality with emoji reactions, custom reactions, reaction roles, and reaction-based interactions.
+
+## Discord Equivalent
+Discord's message reaction system with emoji reactions, custom server emoji reactions, reaction roles, and reaction-based automation.
+
+## User Value Proposition
+- **Quick Feedback**: Express sentiment without full messages
+- **Community Engagement**: Lightweight interaction mechanism
+- **Reaction Roles**: Automated role assignment based on reactions
+- **Voting/Polling**: Quick polls using reaction counts
+- **Reduced Noise**: Less chat clutter from +1 type messages
+
+## Technical Complexity: P2
+- **Reaction Storage**: Efficient storage of reactions per message
+- **Real-time Updates**: Live reaction count updates via WebSocket
+- **Reaction Roles**: Automated role assignment system
+- **Permission System**: Who can react with what emojis
+- **Rate Limiting**: Prevent reaction spam
+
+## Implementation Sketch
+```
+Backend:
+- message_reactions table with user and emoji tracking
+- reaction_roles system for automated role assignment
+- Real-time reaction events via WebSocket
+- Reaction permission validation
+- Anti-spam measures for reactions
+
+Database Schema:
+- message_reactions (message_id, user_id, emoji_id, created_at)
+- reaction_roles (server_id, message_id, emoji_id, role_id)
+- reaction_rate_limits (user_id, last_reaction, count)
+
+Frontend:
+- Reaction picker UI with emoji search
+- Reaction display under messages
+- Reaction role setup interface
+- Reaction management for moderators
+```
+
+## Reaction Types
+```
+Standard Reactions:
+- Unicode emoji reactions (👍, ❤️, etc.)
+- Custom server emoji reactions
+- Animated emoji reactions (premium)
+- External emoji reactions (cross-server)
+
+Special Reactions:
+- Reaction roles (role assignment)
+- Reaction removal (auto-delete after time)
+- Reaction voting (poll-style reactions)
+- Reaction threads (start thread from reaction)
+```
+
+## Reaction Roles System
+```
+Setup:
+- Moderators configure message + emoji + role combinations
+- Users react to get roles automatically
+- Support for exclusive role groups
+- Reaction role limits per server
+
+Functionality:
+- Instant role assignment on reaction
+- Role removal on reaction removal
+- Role limits and prerequisites
+- Audit logging for role changes
+```
+
+## Dependencies
+- Message system (✓ implemented)
+- Emoji system (✓ implemented)
+- Role system (✓ implemented)
+- WebSocket system (✓ implemented)
+- Permission system (✓ implemented)
+
+## Permission Controls
+- REACT_WITH_EMOJI
+- MANAGE_REACTIONS (remove others' reactions)
+- USE_EXTERNAL_EMOJIS (cross-server emoji)
+- REACTION_ROLE_SETUP (configure reaction roles)
+
+## Anti-Spam Measures
+- Rate limiting (max reactions per minute)
+- Reaction duplicate prevention
+- Bulk reaction detection
+- Automated cleanup of spam reactions
+
+## Success Metrics
+- Reaction usage rate (reactions per message)
+- Reaction role adoption (servers using feature)
+- User engagement increase via reactions
+- Reduction in +1 style messages
+
+## Priority Justification
+Message reactions are a core engagement feature in Discord that significantly reduces chat noise while increasing user interaction. Essential for community building and user retention.

--- a/TASK_QUEUE.md
+++ b/TASK_QUEUE.md
@@ -44,3 +44,9 @@
 - [ ] **[P0]** Feature: Voice Messages — Audio message recording and playback in text channels for mobile-first communication
 - [ ] **[P0]** Feature: Enhanced Mobile Experience — Mobile-first UI patterns and optimizations for competitive mobile parity
 - [ ] **[P1]** Feature: Server Insights Dashboard — Analytics and metrics dashboard for community management and growth tracking
+
+## 2026-03-31 Critical Feature Gap Analysis
+
+- [ ] **[P0]** Feature: Bot API and Developer Platform — Essential developer ecosystem with bot creation, OAuth2, and API access for third-party integrations
+- [ ] **[P0]** Feature: Live Video Streaming — Go Live functionality for streaming games/applications to voice channel audiences
+- [ ] **[P0]** Feature: Advanced Permissions System — Fine-grained permission controls with role hierarchies and channel overrides

--- a/backend/internal/api/handlers/component_handler.go
+++ b/backend/internal/api/handlers/component_handler.go
@@ -1,31 +1,55 @@
 package handlers
 
 import (
+	"context"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
 	"hearth/internal/models"
-	"hearth/internal/services"
 )
+
+// ComponentServiceInterface defines the methods needed from ComponentService
+type ComponentServiceInterface interface {
+	GetMessageComponents(ctx context.Context, messageID uuid.UUID) ([]*models.MessageComponent, error)
+	HandleInteraction(ctx context.Context, userID, channelID, messageID, componentID uuid.UUID, customID string, values []string) (*models.ComponentInteraction, error)
+	UpdateMessageComponents(ctx context.Context, messageID uuid.UUID, components []*models.MessageComponent) ([]*models.MessageComponent, error)
+	RemoveAllComponents(ctx context.Context, messageID uuid.UUID) error
+}
+
+// MessageServiceGetMessageInterface defines the GetMessage method needed from MessageService
+type MessageServiceGetMessageInterface interface {
+	GetMessage(ctx context.Context, messageID uuid.UUID, requesterID uuid.UUID) (*models.Message, error)
+}
+
+// ChannelServiceGetChannelInterface defines the GetChannel method needed from ChannelService
+type ChannelServiceGetChannelInterface interface {
+	GetChannel(ctx context.Context, channelID uuid.UUID) (*models.Channel, error)
+}
+
+// PermissionServiceGetChannelPermissionsInterface defines the GetChannelPermissions method needed from PermissionService
+type PermissionServiceGetChannelPermissionsInterface interface {
+	GetChannelPermissions(ctx context.Context, channel *models.Channel, userID uuid.UUID) (int64, error)
+}
 
 // ComponentHandler handles component-related HTTP requests
 type ComponentHandler struct {
-	componentService  *services.ComponentService
-	messageService    *services.MessageService
-	channelService    *services.ChannelService
-	permissionService *services.PermissionService
+	componentService  ComponentServiceInterface
+	messageService   MessageServiceGetMessageInterface
+	channelService   ChannelServiceGetChannelInterface
+	permissionService PermissionServiceGetChannelPermissionsInterface
 }
 
 // NewComponentHandler creates a new component handler
 func NewComponentHandler(
-	componentService *services.ComponentService,
-	messageService *services.MessageService,
-	channelService *services.ChannelService,
-	permissionService *services.PermissionService,
+	componentService ComponentServiceInterface,
+	messageService MessageServiceGetMessageInterface,
+	channelService ChannelServiceGetChannelInterface,
+	permissionService PermissionServiceGetChannelPermissionsInterface,
 ) *ComponentHandler {
 	return &ComponentHandler{
-		componentService:  componentService,
-		messageService:    messageService,
+		componentService:   componentService,
+		messageService:     messageService,
 		channelService:    channelService,
 		permissionService: permissionService,
 	}

--- a/backend/internal/api/handlers/component_handler_test.go
+++ b/backend/internal/api/handlers/component_handler_test.go
@@ -1,0 +1,751 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"hearth/internal/models"
+)
+
+// =============================================================================
+// Mock implementations for ComponentHandler testing
+// =============================================================================
+
+// mockComponentHandlerComponentService mocks ComponentServiceInterface
+type mockComponentHandlerComponentService struct {
+	getMessageComponentsFunc    func(ctx context.Context, messageID uuid.UUID) ([]*models.MessageComponent, error)
+	handleInteractionFunc       func(ctx context.Context, userID, channelID, messageID, componentID uuid.UUID, customID string, values []string) (*models.ComponentInteraction, error)
+	updateMessageComponentsFunc func(ctx context.Context, messageID uuid.UUID, components []*models.MessageComponent) ([]*models.MessageComponent, error)
+	removeAllComponentsFunc    func(ctx context.Context, messageID uuid.UUID) error
+}
+
+func (m *mockComponentHandlerComponentService) GetMessageComponents(ctx context.Context, messageID uuid.UUID) ([]*models.MessageComponent, error) {
+	if m.getMessageComponentsFunc != nil {
+		return m.getMessageComponentsFunc(ctx, messageID)
+	}
+	return nil, nil
+}
+
+func (m *mockComponentHandlerComponentService) HandleInteraction(ctx context.Context, userID, channelID, messageID, componentID uuid.UUID, customID string, values []string) (*models.ComponentInteraction, error) {
+	if m.handleInteractionFunc != nil {
+		return m.handleInteractionFunc(ctx, userID, channelID, messageID, componentID, customID, values)
+	}
+	return nil, nil
+}
+
+func (m *mockComponentHandlerComponentService) UpdateMessageComponents(ctx context.Context, messageID uuid.UUID, components []*models.MessageComponent) ([]*models.MessageComponent, error) {
+	if m.updateMessageComponentsFunc != nil {
+		return m.updateMessageComponentsFunc(ctx, messageID, components)
+	}
+	return nil, nil
+}
+
+func (m *mockComponentHandlerComponentService) RemoveAllComponents(ctx context.Context, messageID uuid.UUID) error {
+	if m.removeAllComponentsFunc != nil {
+		return m.removeAllComponentsFunc(ctx, messageID)
+	}
+	return nil
+}
+
+// mockComponentHandlerMessageService mocks MessageServiceGetMessageInterface
+type mockComponentHandlerMessageService struct {
+	getMessageFunc func(ctx context.Context, messageID, userID uuid.UUID) (*models.Message, error)
+}
+
+func (m *mockComponentHandlerMessageService) GetMessage(ctx context.Context, messageID, userID uuid.UUID) (*models.Message, error) {
+	if m.getMessageFunc != nil {
+		return m.getMessageFunc(ctx, messageID, userID)
+	}
+	return nil, nil
+}
+
+// mockComponentHandlerChannelService mocks ChannelServiceGetChannelInterface
+type mockComponentHandlerChannelService struct {
+	getChannelFunc func(ctx context.Context, channelID uuid.UUID) (*models.Channel, error)
+}
+
+func (m *mockComponentHandlerChannelService) GetChannel(ctx context.Context, channelID uuid.UUID) (*models.Channel, error) {
+	if m.getChannelFunc != nil {
+		return m.getChannelFunc(ctx, channelID)
+	}
+	return nil, nil
+}
+
+// mockComponentHandlerPermissionService mocks PermissionServiceGetChannelPermissionsInterface
+type mockComponentHandlerPermissionService struct {
+	getChannelPermissionsFunc func(ctx context.Context, channel *models.Channel, userID uuid.UUID) (int64, error)
+}
+
+func (m *mockComponentHandlerPermissionService) GetChannelPermissions(ctx context.Context, channel *models.Channel, userID uuid.UUID) (int64, error) {
+	if m.getChannelPermissionsFunc != nil {
+		return m.getChannelPermissionsFunc(ctx, channel, userID)
+	}
+	return 0, nil
+}
+
+// componentHandlerRouter creates a Fiber app with ComponentHandler routes for testing
+func setupComponentHandlerTestApp(t *testing.T, h *ComponentHandler) *fiber.App {
+	app := fiber.New()
+	t.Cleanup(func() { app.Shutdown() })
+
+	// Inject userID middleware
+	app.Use(func(c *fiber.Ctx) error {
+		userID := c.Get("X-User-ID")
+		if userID != "" {
+			id, _ := uuid.Parse(userID)
+			c.Locals("userID", id)
+		}
+		return c.Next()
+	})
+
+	// HandleComponentInteractionV2 - POST /api/v1/interactions/components
+	app.Post("/api/v1/interactions/components", h.HandleComponentInteractionV2)
+
+	// GetMessageComponents - GET /api/v1/channels/:id/messages/:messageId/components
+	app.Get("/api/v1/channels/:id/messages/:messageId/components", h.GetMessageComponents)
+
+	// UpdateMessageComponents - PATCH /api/v1/channels/:id/messages/:messageId/components
+	app.Patch("/api/v1/channels/:id/messages/:messageId/components", h.UpdateMessageComponents)
+
+	// RemoveAllComponents - DELETE /api/v1/channels/:id/messages/:messageId/components
+	app.Delete("/api/v1/channels/:id/messages/:messageId/components", h.RemoveAllComponents)
+
+	return app
+}
+
+
+
+// =============================================================================
+// Tests for HandleComponentInteractionV2
+// =============================================================================
+
+func TestComponentHandler_HandleComponentInteractionV2_Success(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	handler := &ComponentHandler{componentService: componentSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+	componentID := uuid.New()
+	customID := "my_button"
+
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return []*models.MessageComponent{{ID: componentID, CustomID: customID, Type: models.ComponentTypeButton}}, nil
+	}
+	componentSvc.handleInteractionFunc = func(ctx context.Context, uid, chID, msgID, compID uuid.UUID, custID string, vals []string) (*models.ComponentInteraction, error) {
+		return &models.ComponentInteraction{ID: uuid.New(), UserID: uid, ChannelID: chID, MessageID: msgID, ComponentID: compID, CustomID: custID}, nil
+	}
+
+	body := map[string]interface{}{"message_id": messageID.String(), "channel_id": channelID.String(), "custom_id": customID}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var interaction models.ComponentInteraction
+	err = json.NewDecoder(resp.Body).Decode(&interaction)
+	assert.NoError(t, err)
+	assert.Equal(t, userID, interaction.UserID)
+	assert.Equal(t, channelID, interaction.ChannelID)
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_InvalidJSON(t *testing.T) {
+	handler := &ComponentHandler{componentService: &mockComponentHandlerComponentService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader([]byte(`{invalid`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_MissingFields(t *testing.T) {
+	handler := &ComponentHandler{componentService: &mockComponentHandlerComponentService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	body := map[string]interface{}{"message_id": uuid.New().String()}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "required")
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_InvalidMessageUUID(t *testing.T) {
+	handler := &ComponentHandler{componentService: &mockComponentHandlerComponentService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	body := map[string]interface{}{"message_id": "not-a-uuid", "channel_id": uuid.New().String(), "custom_id": "btn"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "message ID")
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_InvalidChannelUUID(t *testing.T) {
+	handler := &ComponentHandler{componentService: &mockComponentHandlerComponentService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	body := map[string]interface{}{"message_id": uuid.New().String(), "channel_id": "not-a-uuid", "custom_id": "btn"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "channel ID")
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_ComponentNotFound(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	handler := &ComponentHandler{componentService: componentSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return []*models.MessageComponent{{ID: uuid.New(), CustomID: "other_btn", Type: models.ComponentTypeButton}}, nil
+	}
+
+	body := map[string]interface{}{"message_id": uuid.New().String(), "channel_id": uuid.New().String(), "custom_id": "my_btn"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "not found")
+}
+
+func TestComponentHandler_HandleComponentInteractionV2_ServiceError(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	handler := &ComponentHandler{componentService: componentSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return []*models.MessageComponent{{ID: uuid.New(), CustomID: "btn", Type: models.ComponentTypeButton}}, nil
+	}
+	componentSvc.handleInteractionFunc = func(ctx context.Context, uid, chID, msgID, compID uuid.UUID, custID string, vals []string) (*models.ComponentInteraction, error) {
+		return nil, errors.New("service error")
+	}
+
+	body := map[string]interface{}{"message_id": uuid.New().String(), "channel_id": uuid.New().String(), "custom_id": "btn"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/interactions/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+// =============================================================================
+// Tests for GetMessageComponents
+// =============================================================================
+
+func TestComponentHandler_GetMessageComponents_Success(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: uID}, nil
+	}
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return []*models.MessageComponent{
+			{ID: uuid.New(), CustomID: "btn_1", Type: models.ComponentTypeButton, Label: "Click me"},
+			{ID: uuid.New(), CustomID: "btn_2", Type: models.ComponentTypeButton, Label: "Or me"},
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var components []*models.MessageComponent
+	err = json.NewDecoder(resp.Body).Decode(&components)
+	assert.NoError(t, err)
+	assert.Len(t, components, 2)
+}
+
+func TestComponentHandler_GetMessageComponents_EmptyComponents(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: uID}, nil
+	}
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return []*models.MessageComponent{}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var components []*models.MessageComponent
+	err = json.NewDecoder(resp.Body).Decode(&components)
+	assert.NoError(t, err)
+	assert.Len(t, components, 0)
+}
+
+func TestComponentHandler_GetMessageComponents_NilComponents(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: uID}, nil
+	}
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func TestComponentHandler_GetMessageComponents_InvalidMessageID(t *testing.T) {
+	handler := &ComponentHandler{componentService: &mockComponentHandlerComponentService{}, messageService: &mockComponentHandlerMessageService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+uuid.New().String()+"/messages/not-a-uuid/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "message ID")
+}
+
+func TestComponentHandler_GetMessageComponents_MessageNotFound(t *testing.T) {
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+uuid.New().String()+"/messages/"+uuid.New().String()+"/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+func TestComponentHandler_GetMessageComponents_ServiceError(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	channelID := uuid.New()
+	messageID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: uID}, nil
+	}
+	componentSvc.getMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID) ([]*models.MessageComponent, error) {
+		return nil, errors.New("database error")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+// =============================================================================
+// Tests for UpdateMessageComponents
+// =============================================================================
+
+func TestComponentHandler_UpdateMessageComponents_AsAuthor_Success(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: userID}, nil
+	}
+	componentSvc.updateMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID, components []*models.MessageComponent) ([]*models.MessageComponent, error) {
+		return components, nil
+	}
+
+	body := models.UpdateComponentsRequest{Components: []models.CreateComponentRequest{{Type: models.ComponentTypeButton, Style: models.ButtonStylePrimary, Label: "New Button", CustomID: "new_btn"}}}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var updated []*models.MessageComponent
+	err = json.NewDecoder(resp.Body).Decode(&updated)
+	assert.NoError(t, err)
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "New Button", updated[0].Label)
+}
+
+func TestComponentHandler_UpdateMessageComponents_WithManageMessagesPermission(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	channelSvc := &mockComponentHandlerChannelService{}
+	permSvc := &mockComponentHandlerPermissionService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc, channelService: channelSvc, permissionService: permSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	authorID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: authorID}, nil
+	}
+	channelSvc.getChannelFunc = func(ctx context.Context, chID uuid.UUID) (*models.Channel, error) {
+		return &models.Channel{ID: channelID}, nil
+	}
+	permSvc.getChannelPermissionsFunc = func(ctx context.Context, channel *models.Channel, uID uuid.UUID) (int64, error) {
+		return models.PermManageMessages, nil
+	}
+	componentSvc.updateMessageComponentsFunc = func(ctx context.Context, msgID uuid.UUID, components []*models.MessageComponent) ([]*models.MessageComponent, error) {
+		return components, nil
+	}
+
+	body := models.UpdateComponentsRequest{Components: []models.CreateComponentRequest{{Type: models.ComponentTypeButton, CustomID: "btn"}}}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func TestComponentHandler_UpdateMessageComponents_NotAuthorNoPermission(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	channelSvc := &mockComponentHandlerChannelService{}
+	permSvc := &mockComponentHandlerPermissionService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc, channelService: channelSvc, permissionService: permSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	authorID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: authorID}, nil
+	}
+	channelSvc.getChannelFunc = func(ctx context.Context, chID uuid.UUID) (*models.Channel, error) {
+		return &models.Channel{ID: channelID}, nil
+	}
+	permSvc.getChannelPermissionsFunc = func(ctx context.Context, channel *models.Channel, uID uuid.UUID) (int64, error) {
+		return 0, nil
+	}
+
+	body := models.UpdateComponentsRequest{Components: []models.CreateComponentRequest{{Type: models.ComponentTypeButton, CustomID: "btn"}}}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "permission")
+}
+
+func TestComponentHandler_UpdateMessageComponents_InvalidJSON(t *testing.T) {
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: userID}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", bytes.NewReader([]byte(`{invalid}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestComponentHandler_UpdateMessageComponents_InvalidMessageID(t *testing.T) {
+	handler := &ComponentHandler{messageService: &mockComponentHandlerMessageService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+uuid.New().String()+"/messages/not-a-uuid/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "message ID")
+}
+
+func TestComponentHandler_UpdateMessageComponents_MessageNotFound(t *testing.T) {
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return nil, nil
+	}
+
+	body := models.UpdateComponentsRequest{Components: []models.CreateComponentRequest{{Type: models.ComponentTypeButton}}}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+uuid.New().String()+"/messages/"+uuid.New().String()+"/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+func TestComponentHandler_UpdateMessageComponents_ChannelNotFound(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	channelSvc := &mockComponentHandlerChannelService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc, channelService: channelSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	authorID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: authorID}, nil
+	}
+	channelSvc.getChannelFunc = func(ctx context.Context, chID uuid.UUID) (*models.Channel, error) {
+		return nil, nil
+	}
+
+	body := models.UpdateComponentsRequest{Components: []models.CreateComponentRequest{{Type: models.ComponentTypeButton}}}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+// =============================================================================
+// Tests for RemoveAllComponents
+// =============================================================================
+
+func TestComponentHandler_RemoveAllComponents_AsAuthor_Success(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: userID}, nil
+	}
+	componentSvc.removeAllComponentsFunc = func(ctx context.Context, msgID uuid.UUID) error {
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+}
+
+func TestComponentHandler_RemoveAllComponents_NotAuthor(t *testing.T) {
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	authorID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: authorID}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "author")
+}
+
+func TestComponentHandler_RemoveAllComponents_InvalidMessageID(t *testing.T) {
+	handler := &ComponentHandler{messageService: &mockComponentHandlerMessageService{}}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/"+uuid.New().String()+"/messages/not-a-uuid/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	respBody := readBody(resp.Body)
+	assert.Contains(t, respBody, "message ID")
+}
+
+func TestComponentHandler_RemoveAllComponents_MessageNotFound(t *testing.T) {
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/"+uuid.New().String()+"/messages/"+uuid.New().String()+"/components", nil)
+	req.Header.Set("X-User-ID", uuid.New().String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+func TestComponentHandler_RemoveAllComponents_ServiceError(t *testing.T) {
+	componentSvc := &mockComponentHandlerComponentService{}
+	messageSvc := &mockComponentHandlerMessageService{}
+	handler := &ComponentHandler{componentService: componentSvc, messageService: messageSvc}
+	app := setupComponentHandlerTestApp(t, handler)
+
+	userID := uuid.New()
+	messageID := uuid.New()
+	channelID := uuid.New()
+
+	messageSvc.getMessageFunc = func(ctx context.Context, msgID, uID uuid.UUID) (*models.Message, error) {
+		return &models.Message{ID: msgID, ChannelID: channelID, AuthorID: userID}, nil
+	}
+	componentSvc.removeAllComponentsFunc = func(ctx context.Context, msgID uuid.UUID) error {
+		return errors.New("database error")
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/"+channelID.String()+"/messages/"+messageID.String()+"/components", nil)
+	req.Header.Set("X-User-ID", userID.String())
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}


### PR DESCRIPTION
This commit improves test coverage for the ComponentHandler by:
1. Refactoring ComponentHandler to use interfaces for its service
   dependencies (ComponentServiceInterface, MessageServiceGetMessageInterface,
   ChannelServiceGetChannelInterface, PermissionServiceGetChannelPermissionsInterface)
   following the pattern established by AnalyticsHandler.
2. Adding comprehensive unit tests for all 4 handler methods:
   - HandleComponentInteractionV2 (7 tests)
   - GetMessageComponents (6 tests)
   - UpdateMessageComponents (7 tests)
   - RemoveAllComponents (5 tests)

All tests cover success cases, validation errors, permission checks,
and service error handling.
