### PR TITLE
feat(polls): implement PollRepository and wire up PollService

### DIFF
--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -283,6 +283,7 @@ func main() {
 		messageService,
 		serviceBus,
 	)
+	pollService := services.NewPollService(repos.Polls)
 
 	// Initialize voice signaling service
 	var voiceService *websocket.VoiceSignalingService
@@ -410,6 +411,9 @@ func main() {
 	)
 
 	h := handlers.NewHandlersWithTyping(authService, userService, serverService, channelService, messageService, roleService, searchService, threadService, typingService, webhookService, wsGateway, voiceService)
+
+	// Wire up Poll handler
+	h.SetPollHandler(pollService)
 
 	// Wire up OAuth service if available
 	if oauthService != nil {

--- a/backend/internal/api/handlers/handlers.go
+++ b/backend/internal/api/handlers/handlers.go
@@ -73,6 +73,11 @@ func (h *Handlers) SetWebhookHandler(webhookService *services.WebhookService) {
 	h.Webhooks = NewWebhookHandlers(webhookService)
 }
 
+// SetPollHandler sets the poll handler
+func (h *Handlers) SetPollHandler(pollService *services.PollService) {
+	h.Polls = NewPollHandler(pollService)
+}
+
 // SetStickerHandler sets the sticker handler
 func (h *Handlers) SetStickerHandler(stickerService *services.StickerService, serverService *services.ServerService, permService *services.PermissionService) {
 	h.Stickers = NewStickerHandler(stickerService, serverService, permService)

--- a/backend/internal/api/handlers/polls.go
+++ b/backend/internal/api/handlers/polls.go
@@ -18,6 +18,7 @@ type PollServiceInterface interface {
 	UpdatePoll(ctx context.Context, poll *models.Poll) error
 	DeletePoll(ctx context.Context, id uuid.UUID) error
 	GetGuildPolls(ctx context.Context, guildID uuid.UUID) ([]*models.Poll, error)
+	GetChannelPolls(ctx context.Context, channelID uuid.UUID) ([]*models.Poll, error)
 	Vote(ctx context.Context, pollID, optionID, userID uuid.UUID) error
 }
 
@@ -377,9 +378,7 @@ func (h *PollHandler) GetChannelPolls(c *fiber.Ctx) error {
 		})
 	}
 
-	// Note: Using GetGuildPolls as it's already implemented
-	// In a real implementation, we'd have GetByChannelID
-	polls, err := h.pollService.GetGuildPolls(c.Context(), channelID)
+	polls, err := h.pollService.GetChannelPolls(c.Context(), channelID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to get polls",

--- a/backend/internal/database/postgres/db.go
+++ b/backend/internal/database/postgres/db.go
@@ -163,6 +163,7 @@ type Repositories struct {
 	ServerAudioSettings  *ServerAudioSettingsRepository
 	Premium              *PremiumRepository
 	Search               *SearchRepository
+	Polls                *PollRepository
 }
 
 // NewRepositories creates all repositories
@@ -190,5 +191,6 @@ func NewRepositories(db *sqlx.DB) *Repositories {
 		ServerAudioSettings:  NewServerAudioSettingsRepository(db),
 		Premium:              NewPremiumRepository(db),
 		Search:               NewSearchRepository(db),
+		Polls:                NewPollRepository(db),
 	}
 }

--- a/backend/internal/database/postgres/migrations/036_polls.sql
+++ b/backend/internal/database/postgres/migrations/036_polls.sql
@@ -1,0 +1,94 @@
+-- Hearth Database Schema
+-- Migration 036: Poll System
+
+-- Polls table
+CREATE TABLE polls (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    channel_id UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    question TEXT NOT NULL,
+    is_multiple BOOLEAN NOT NULL DEFAULT FALSE,
+    end_time TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index for fetching polls by channel
+CREATE INDEX idx_polls_channel_id ON polls(channel_id);
+
+-- Index for fetching polls by server (via channel)
+CREATE INDEX idx_polls_server ON polls(channel_id);
+
+-- Poll options table
+CREATE TABLE poll_options (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    poll_id UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+    text TEXT NOT NULL,
+    votes INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index for fetching options by poll
+CREATE INDEX idx_poll_options_poll_id ON poll_options(poll_id);
+
+-- Poll votes table (tracks who voted for what)
+CREATE TABLE poll_votes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    poll_id UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+    option_id UUID NOT NULL REFERENCES poll_options(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(poll_id, user_id) -- one vote per user per poll
+);
+
+-- Index for checking if user has voted
+CREATE INDEX idx_poll_votes_poll_user ON poll_votes(poll_id, user_id);
+
+-- Index for counting votes per option
+CREATE INDEX idx_poll_votes_option_id ON poll_votes(option_id);
+
+-- Function to update poll updated_at timestamp
+CREATE OR REPLACE FUNCTION update_poll_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-update poll timestamp
+DROP TRIGGER IF EXISTS trigger_poll_updated_at ON polls;
+CREATE TRIGGER trigger_poll_updated_at
+    BEFORE UPDATE ON polls
+    FOR EACH ROW
+    EXECUTE FUNCTION update_poll_timestamp();
+
+-- Trigger to update option vote count on insert
+CREATE OR REPLACE FUNCTION increment_poll_option_votes()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE poll_options SET votes = votes + 1 WHERE id = NEW.option_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_poll_vote_increment ON poll_votes;
+CREATE TRIGGER trigger_poll_vote_increment
+    AFTER INSERT ON poll_votes
+    FOR EACH ROW
+    EXECUTE FUNCTION increment_poll_option_votes();
+
+-- Trigger to decrement vote count on vote deletion (for vote changing)
+CREATE OR REPLACE FUNCTION decrement_poll_option_votes()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE poll_options SET votes = GREATEST(0, votes - 1) WHERE id = OLD.option_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_poll_vote_decrement ON poll_votes;
+CREATE TRIGGER trigger_poll_vote_decrement
+    AFTER DELETE ON poll_votes
+    FOR EACH ROW
+    EXECUTE FUNCTION decrement_poll_option_votes();

--- a/backend/internal/database/postgres/poll_repo.go
+++ b/backend/internal/database/postgres/poll_repo.go
@@ -1,0 +1,203 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"hearth/internal/models"
+)
+
+// PollRepository handles poll data access
+type PollRepository struct {
+	db *sqlx.DB
+}
+
+// NewPollRepository creates a new poll repository
+func NewPollRepository(db *sqlx.DB) *PollRepository {
+	return &PollRepository{db: db}
+}
+
+// Create inserts a new poll with its options
+func (r *PollRepository) Create(ctx context.Context, poll *models.Poll) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Insert poll
+	pollQuery := `
+		INSERT INTO polls (id, channel_id, creator_id, question, is_multiple, end_time, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	_, err = tx.ExecContext(ctx, pollQuery,
+		poll.ID, poll.ChannelID, poll.CreatorID, poll.Question,
+		poll.IsMultiple, poll.EndTime, poll.CreatedAt, poll.UpdatedAt)
+	if err != nil {
+		return err
+	}
+
+	// Insert options
+	optQuery := `
+		INSERT INTO poll_options (id, poll_id, text, votes, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	for _, opt := range poll.Options {
+		_, err = tx.ExecContext(ctx, optQuery, opt.ID, poll.ID, opt.Text, opt.Votes, time.Now())
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetByID retrieves a poll with its options
+func (r *PollRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.Poll, error) {
+	var poll models.Poll
+	pollQuery := `
+		SELECT id, channel_id, creator_id, question, is_multiple, end_time, created_at, updated_at
+		FROM polls WHERE id = $1
+	`
+	err := r.db.GetContext(ctx, &poll, pollQuery, id)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Get options
+	var options []models.PollOption
+	optQuery := `SELECT id, poll_id, text, votes, created_at FROM poll_options WHERE poll_id = $1`
+	err = r.db.SelectContext(ctx, &options, optQuery, id)
+	if err != nil {
+		return nil, err
+	}
+	poll.Options = options
+
+	return &poll, nil
+}
+
+// Update updates an existing poll
+func (r *PollRepository) Update(ctx context.Context, poll *models.Poll) error {
+	query := `
+		UPDATE polls
+		SET question = $2, is_multiple = $3, end_time = $4, updated_at = $5
+		WHERE id = $1
+	`
+	_, err := r.db.ExecContext(ctx, query, poll.ID, poll.Question, poll.IsMultiple, poll.EndTime, poll.UpdatedAt)
+	return err
+}
+
+// Delete removes a poll and its options/votes (cascades)
+func (r *PollRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM polls WHERE id = $1`, id)
+	return err
+}
+
+// GetByChannelID retrieves all polls for a channel
+func (r *PollRepository) GetByChannelID(ctx context.Context, channelID uuid.UUID) ([]*models.Poll, error) {
+	var polls []*models.Poll
+	query := `
+		SELECT id, channel_id, creator_id, question, is_multiple, end_time, created_at, updated_at
+		FROM polls WHERE channel_id = $1 ORDER BY created_at DESC
+	`
+	err := r.db.SelectContext(ctx, &polls, query, channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load options for each poll
+	for _, poll := range polls {
+		var options []models.PollOption
+		err = r.db.SelectContext(ctx, &options, `SELECT id, poll_id, text, votes, created_at FROM poll_options WHERE poll_id = $1`, poll.ID)
+		if err != nil {
+			return nil, err
+		}
+		poll.Options = options
+	}
+
+	return polls, nil
+}
+
+// GetByGuildID retrieves all polls for a server (via channel guild mapping)
+func (r *PollRepository) GetByGuildID(ctx context.Context, guildID uuid.UUID) ([]*models.Poll, error) {
+	var polls []*models.Poll
+	query := `
+		SELECT p.id, p.channel_id, p.creator_id, p.question, p.is_multiple, p.end_time, p.created_at, p.updated_at
+		FROM polls p
+		INNER JOIN channels c ON p.channel_id = c.id
+		WHERE c.server_id = $1
+		ORDER BY p.created_at DESC
+	`
+	err := r.db.SelectContext(ctx, &polls, query, guildID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load options for each poll
+	for _, poll := range polls {
+		var options []models.PollOption
+		err = r.db.SelectContext(ctx, &options, `SELECT id, poll_id, text, votes, created_at FROM poll_options WHERE poll_id = $1`, poll.ID)
+		if err != nil {
+			return nil, err
+		}
+		poll.Options = options
+	}
+
+	return polls, nil
+}
+
+// VoteForOption casts a vote for a user on a poll option.
+// It is called AFTER the service has verified the user hasn't already voted.
+// The vote is recorded in a transaction.
+func (r *PollRepository) VoteForOption(ctx context.Context, pollID, optionID, userID uuid.UUID) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Insert the new vote - trigger handles vote count increment
+	voteQuery := `
+		INSERT INTO poll_votes (id, poll_id, option_id, user_id, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	_, err = tx.ExecContext(ctx, voteQuery, uuid.New(), pollID, optionID, userID, time.Now())
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// CheckUserVote checks if a user has already voted on a poll
+func (r *PollRepository) CheckUserVote(ctx context.Context, pollID, userID uuid.UUID) (*models.PollOptionVote, error) {
+	var vote models.PollOptionVote
+	query := `
+		SELECT id, poll_id, option_id, user_id, created_at
+		FROM poll_votes
+		WHERE poll_id = $1 AND user_id = $2
+	`
+	err := r.db.GetContext(ctx, &vote, query, pollID, userID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &vote, nil
+}

--- a/backend/internal/services/errors.go
+++ b/backend/internal/services/errors.go
@@ -110,4 +110,8 @@ var (
 
 	// Audit log errors
 	ErrAuditLogNotFound = errors.New("audit log entry not found")
+
+	// Poll errors
+	ErrPollClosed   = errors.New("poll is closed")
+	ErrPollNotFound = errors.New("poll not found")
 )

--- a/backend/internal/services/poll_service.go
+++ b/backend/internal/services/poll_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"hearth/internal/models"
@@ -16,8 +17,9 @@ type PollRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*models.Poll, error)
 	Update(ctx context.Context, poll *models.Poll) error
 	Delete(ctx context.Context, id uuid.UUID) error
+	GetByChannelID(ctx context.Context, channelID uuid.UUID) ([]*models.Poll, error)
 	GetByGuildID(ctx context.Context, guildID uuid.UUID) ([]*models.Poll, error)
-	VoteForOption(ctx context.Context, pollID, optionID uuid.UUID) error
+	VoteForOption(ctx context.Context, pollID, optionID, userID uuid.UUID) error
 	CheckUserVote(ctx context.Context, pollID, userID uuid.UUID) (*models.PollOptionVote, error)
 }
 
@@ -73,26 +75,39 @@ func (s *PollService) GetGuildPolls(ctx context.Context, guildID uuid.UUID) ([]*
 	return s.repo.GetByGuildID(ctx, guildID)
 }
 
+// GetChannelPolls retrieves all polls for a specific channel.
+func (s *PollService) GetChannelPolls(ctx context.Context, channelID uuid.UUID) ([]*models.Poll, error) {
+	if channelID == uuid.Nil {
+		return nil, errors.New("invalid channel ID")
+	}
+	return s.repo.GetByChannelID(ctx, channelID)
+}
+
 // Vote adds a vote to a specific option within a poll.
 func (s *PollService) Vote(ctx context.Context, pollID, optionID, userID uuid.UUID) error {
-	// Validate existing logic: check if user already voted
+	// Check if poll exists and is still open
+	poll, err := s.repo.GetByID(ctx, pollID)
+	if err != nil {
+		return fmt.Errorf("error fetching poll: %w", err)
+	}
+	if poll == nil {
+		return ErrPollNotFound
+	}
+	if poll.EndTime != nil && poll.EndTime.Before(time.Now()) {
+		return ErrPollClosed
+	}
+
+	// Check if user already voted
 	userVote, err := s.repo.CheckUserVote(ctx, pollID, userID)
 	if err != nil {
 		return fmt.Errorf("error checking previous vote: %w", err)
 	}
-
-	// Block re-voting if a vote exists and we are using a persistent vote model.
-	// Note: This logic depends on the specific implementation of models.PollOptionVote.
-	// If models.PollOptionVote allows multiple entries per user per poll, remove this check.
 	if userVote != nil {
 		return errors.New("user has already voted on this poll")
 	}
 
-	// TODO: In Flux architecture, this might be part of a transaction involving:
-	// 1. Deleting old votes for the user
-	// 2. Inserting the new vote
-	// 3. Updating the tally count
-	err = s.repo.VoteForOption(ctx, pollID, optionID)
+	// VoteForOption records the vote in a transaction
+	err = s.repo.VoteForOption(ctx, pollID, optionID, userID)
 	if err != nil {
 		return fmt.Errorf("failed to cast vote: %w", err)
 	}

--- a/backend/internal/services/poll_service_test.go
+++ b/backend/internal/services/poll_service_test.go
@@ -28,6 +28,11 @@ func (m *MockPollRepository) GetByID(ctx context.Context, id uuid.UUID) (*models
 	return args.Get(0).(*models.Poll), args.Error(1)
 }
 
+func (m *MockPollRepository) GetByChannelID(ctx context.Context, channelID uuid.UUID) ([]*models.Poll, error) {
+	args := m.Called(ctx, channelID)
+	return args.Get(0).([]*models.Poll), args.Error(1)
+}
+
 func (m *MockPollRepository) Update(ctx context.Context, poll *models.Poll) error {
 	args := m.Called(ctx, poll)
 	return args.Error(0)
@@ -43,8 +48,8 @@ func (m *MockPollRepository) GetByGuildID(ctx context.Context, guildID uuid.UUID
 	return args.Get(0).([]*models.Poll), args.Error(1)
 }
 
-func (m *MockPollRepository) VoteForOption(ctx context.Context, pollID, optionID uuid.UUID) error {
-	args := m.Called(ctx, pollID, optionID)
+func (m *MockPollRepository) VoteForOption(ctx context.Context, pollID, optionID, userID uuid.UUID) error {
+	args := m.Called(ctx, pollID, optionID, userID)
 	return args.Error(0)
 }
 
@@ -116,9 +121,19 @@ func TestPollService_Vote(t *testing.T) {
 	optionID := uuid.New()
 	userID := uuid.New()
 
+	// Create a valid open poll for testing
+	openPoll := &models.Poll{
+		ID:        pollID,
+		ChannelID: uuid.New(),
+		CreatorID: uuid.New(),
+		Question:  "Test Poll",
+		EndTime:   nil, // Open poll (no end time)
+	}
+
 	// Scenario 1: Successful Vote
+	repo.On("GetByID", ctx, pollID).Return(openPoll, nil)
 	repo.On("CheckUserVote", ctx, pollID, userID).Return(nil, nil)
-	repo.On("VoteForOption", ctx, pollID, optionID).Return(nil)
+	repo.On("VoteForOption", ctx, pollID, optionID, userID).Return(nil)
 
 	err := service.Vote(ctx, pollID, optionID, userID)
 	assert.NoError(t, err)
@@ -126,8 +141,8 @@ func TestPollService_Vote(t *testing.T) {
 
 	// Scenario 2: User Already Voted
 	repo.ExpectedCalls = nil
+	repo.On("GetByID", ctx, pollID).Return(openPoll, nil)
 	repo.On("CheckUserVote", ctx, pollID, userID).Return(&models.PollOptionVote{}, nil) // Mock existing vote
-	repo.On("VoteForOption", ctx, pollID, optionID).Return(nil)                         // Should not be called
 
 	err = service.Vote(ctx, pollID, optionID, userID)
 	assert.Error(t, err)


### PR DESCRIPTION
- Add 036_polls.sql migration for polls, poll_options, poll_votes tables
- Implement PollRepository with Create, GetByID, Update, Delete,
  GetByChannelID, GetByGuildID, VoteForOption, CheckUserVote
- Add GetChannelPolls to PollService and interface
- Add ErrPollClosed and ErrPollNotFound to shared errors
- Vote method now checks poll open/closed status before allowing vote
- Update VoteForOption to take userID (passed from service layer)
- Wire up PollHandler via SetPollHandler in main.go
- Add database triggers for automatic vote count maintenance
