### PR TITLE
feat(websocket): add per-IP and per-user connection limits (Redis-backed)

### DIFF
--- a/backend/internal/websocket/gateway.go
+++ b/backend/internal/websocket/gateway.go
@@ -19,8 +19,9 @@ import (
 
 // GatewayConfig holds gateway configuration
 type GatewayConfig struct {
-	HeartbeatInterval time.Duration
-	SessionTimeout    time.Duration
+	HeartbeatInterval  time.Duration
+	SessionTimeout     time.Duration
+	ConnectionLimiter  *ConnectionLimiter
 }
 
 // DefaultGatewayConfig returns default configuration
@@ -28,6 +29,7 @@ func DefaultGatewayConfig() *GatewayConfig {
 	return &GatewayConfig{
 		HeartbeatInterval: 41250 * time.Millisecond, // ~41 seconds
 		SessionTimeout:    5 * time.Minute,
+		ConnectionLimiter: nil, // No connection limiting by default (opt-in)
 	}
 }
 
@@ -52,6 +54,9 @@ type Gateway struct {
 
 	// Prometheus metrics
 	wsMetrics *metrics.WebSocketMetrics
+
+	// Connection limiter (may be nil)
+	connLimiter *ConnectionLimiter
 
 	// Graceful shutdown state
 	draining atomic.Bool
@@ -80,11 +85,12 @@ func NewGateway(hub HubInterface, jwtService *auth.JWTService, config *GatewayCo
 	}
 
 	return &Gateway{
-		hub:        hub,
-		jwtService: jwtService,
-		config:     config,
-		sessions:   make(map[string]*Session),
-		wsMetrics:  metrics.GetMetrics(),
+		hub:         hub,
+		jwtService:  jwtService,
+		config:      config,
+		sessions:    make(map[string]*Session),
+		wsMetrics:   metrics.GetMetrics(),
+		connLimiter: config.ConnectionLimiter,
 	}
 }
 
@@ -125,6 +131,20 @@ func (g *Gateway) HandleConnection(conn *websocket.Conn) {
 		log.Printf("[Gateway] WebSocket auth failed: token validation error for user token: %v", err)
 		g.sendClose(conn, 4001, "authentication failed")
 		return
+	}
+
+	// Extract client IP for connection limiting
+	clientIP := ExtractClientIP(conn)
+
+	// Check per-IP and per-user connection limits (if limiter is configured)
+	if g.connLimiter != nil {
+		result := g.connLimiter.check(context.Background(), clientIP, claims.UserID)
+		if !result.Allowed {
+			log.Printf("[Gateway] Connection rejected for user %s from IP %s: %s (ip_count=%d, user_count=%d)",
+				claims.UserID, clientIP, result.Reason, result.CurrentIPCount, result.CurrentUserCount)
+			g.sendClose(conn, result.Code, result.Reason)
+			return
+		}
 	}
 
 	// Get connection metadata
@@ -174,6 +194,11 @@ func (g *Gateway) HandleConnection(conn *websocket.Conn) {
 	g.wsMetrics.SessionCreated()
 	connectionStart := time.Now()
 
+	// Increment connection counters in Redis (after successful connection setup)
+	if g.connLimiter != nil {
+		g.connLimiter.Increment(context.Background(), clientIP, claims.UserID)
+	}
+
 	defer func() {
 		g.connectionsMu.Lock()
 		g.activeConnections--
@@ -183,6 +208,11 @@ func (g *Gateway) HandleConnection(conn *websocket.Conn) {
 		duration := time.Since(connectionStart).Seconds()
 		g.wsMetrics.ConnectionClosed(clientType, duration)
 		g.wsMetrics.SessionDestroyed()
+
+		// Decrement connection counters in Redis
+		if g.connLimiter != nil {
+			g.connLimiter.Decrement(context.Background(), clientIP, claims.UserID)
+		}
 	}()
 
 	// Create client for hub

--- a/backend/internal/websocket/gateway_ratelimit.go
+++ b/backend/internal/websocket/gateway_ratelimit.go
@@ -1,0 +1,244 @@
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gofiber/contrib/websocket"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// ConnectionLimitConfig holds per-IP and per-user WebSocket connection limits
+type ConnectionLimitConfig struct {
+	// MaxConnectionsPerIP limits concurrent WebSocket connections from a single IP address.
+	// A value of 0 means unlimited.
+	MaxConnectionsPerIP int
+
+	// MaxConnectionsPerUser limits concurrent WebSocket connections for a single user.
+	// A value of 0 means unlimited.
+	MaxConnectionsPerUser int
+
+	// ConnectionTTL is how long a connection entry remains in Redis before expiring.
+	// Should be longer than the WebSocket session timeout.
+	ConnectionTTL time.Duration
+
+	// Enabled controls whether connection limiting is active.
+	Enabled bool
+}
+
+// DefaultConnectionLimitConfig returns sensible defaults
+func DefaultConnectionLimitConfig() *ConnectionLimitConfig {
+	return &ConnectionLimitConfig{
+		MaxConnectionsPerIP:   20,  // 20 connections per IP
+		MaxConnectionsPerUser: 5,   // 5 connections per user (web + mobile + desktop etc.)
+		ConnectionTTL:          10 * time.Minute,
+		Enabled:               true,
+	}
+}
+
+// ConnectionLimiter enforces per-IP and per-user WebSocket connection limits
+// using Redis for distributed coordination across multiple gateway instances.
+type ConnectionLimiter struct {
+	redis    *redis.Client
+	config   *ConnectionLimitConfig
+	keyPrefix string
+}
+
+// NewConnectionLimiter creates a ConnectionLimiter with the given Redis client and config.
+// If redis is nil, the limiter will operate in no-op (allow-all) mode.
+func NewConnectionLimiter(redisClient *redis.Client, config *ConnectionLimitConfig) *ConnectionLimiter {
+	if config == nil {
+		config = DefaultConnectionLimitConfig()
+	}
+	return &ConnectionLimiter{
+		redis:     redisClient,
+		config:    config,
+		keyPrefix: "hearth:ws:conn:",
+	}
+}
+
+// IPKey returns the Redis key for tracking connections from an IP address
+func (l *ConnectionLimiter) IPKey(ip string) string {
+	return l.keyPrefix + "ip:" + ip
+}
+
+// UserKey returns the Redis key for tracking connections for a user
+func (l *ConnectionLimiter) UserKey(userID uuid.UUID) string {
+	return l.keyPrefix + "user:" + userID.String()
+}
+
+// CheckResult describes the result of a connection limit check
+type CheckResult struct {
+	Allowed         bool
+	Reason          string
+	Code            int    // WebSocket close code to send
+	CurrentIPCount  int64  // Current connection count for this IP
+	CurrentUserCount int64 // Current connection count for this user
+}
+
+// check performs the limit check for IP and/or user.
+// Returns a CheckResult indicating whether the connection should be allowed.
+func (l *ConnectionLimiter) check(ctx context.Context, ip string, userID uuid.UUID) CheckResult {
+	// Fast path: if limiting is disabled, allow everything
+	if !l.config.Enabled {
+		return CheckResult{Allowed: true}
+	}
+
+	// Fast path: if Redis is unavailable, fail open (allow) or fail closed based on config
+	if l.redis == nil {
+		log.Printf("[ConnectionLimiter] Redis unavailable, allowing connection (fail-open)")
+		return CheckResult{Allowed: true}
+	}
+
+	result := CheckResult{}
+
+	// Check per-IP limit
+	if l.config.MaxConnectionsPerIP > 0 {
+		ipCount, err := l.redis.Get(ctx, l.IPKey(ip)).Int64()
+		if err != nil && err != redis.Nil {
+			log.Printf("[ConnectionLimiter] Redis error checking IP limit: %v", err)
+			// Fail open on Redis errors to avoid blocking legitimate connections
+			return CheckResult{Allowed: true}
+		}
+		result.CurrentIPCount = ipCount
+		if ipCount >= int64(l.config.MaxConnectionsPerIP) {
+			result.Allowed = false
+			result.Reason = fmt.Sprintf("too many connections from IP (limit: %d)", l.config.MaxConnectionsPerIP)
+			result.Code = 4409 // "Too Many Requests" - close code 4409 is "Rate Limited"
+			return result
+		}
+	}
+
+	// Check per-user limit
+	if l.config.MaxConnectionsPerUser > 0 {
+		userCount, err := l.redis.Get(ctx, l.UserKey(userID)).Int64()
+		if err != nil && err != redis.Nil {
+			log.Printf("[ConnectionLimiter] Redis error checking user limit: %v", err)
+			return CheckResult{Allowed: true}
+		}
+		result.CurrentUserCount = userCount
+		if userCount >= int64(l.config.MaxConnectionsPerUser) {
+			result.Allowed = false
+			result.Reason = fmt.Sprintf("too many connections for user (limit: %d)", l.config.MaxConnectionsPerUser)
+			result.Code = 4409
+			return result
+		}
+	}
+
+	return CheckResult{Allowed: true}
+}
+
+// Increment increments the connection counters for the given IP and user.
+// Must be called after a successful Check() and after the connection is established.
+func (l *ConnectionLimiter) Increment(ctx context.Context, ip string, userID uuid.UUID) {
+	if !l.config.Enabled || l.redis == nil {
+		return
+	}
+
+	ttl := l.config.ConnectionTTL
+	pipe := l.redis.Pipeline()
+
+	if l.config.MaxConnectionsPerIP > 0 {
+		pipe.Incr(ctx, l.IPKey(ip))
+		pipe.Expire(ctx, l.IPKey(ip), ttl)
+	}
+	if l.config.MaxConnectionsPerUser > 0 {
+		pipe.Incr(ctx, l.UserKey(userID))
+		pipe.Expire(ctx, l.UserKey(userID), ttl)
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		log.Printf("[ConnectionLimiter] Redis error incrementing counters: %v", err)
+	}
+}
+
+// Decrement decrements the connection counters for the given IP and user.
+// Must be called when a connection closes.
+func (l *ConnectionLimiter) Decrement(ctx context.Context, ip string, userID uuid.UUID) {
+	if !l.config.Enabled || l.redis == nil {
+		return
+	}
+
+	// Use DECR and ensure we don't go below 0
+	// Note: We use Lua script to atomically decrement and delete if <= 0
+	script := redis.NewScript(`
+		local current = redis.call('DECR', KEYS[1])
+		if current <= 0 then
+			redis.call('DEL', KEYS[1])
+		end
+		return current
+	`)
+
+	if l.config.MaxConnectionsPerIP > 0 {
+		if _, err := script.Run(ctx, l.redis, []string{l.IPKey(ip)}).Result(); err != nil && err != redis.Nil {
+			log.Printf("[ConnectionLimiter] Redis error decrementing IP counter: %v", err)
+		}
+	}
+	if l.config.MaxConnectionsPerUser > 0 {
+		if _, err := script.Run(ctx, l.redis, []string{l.UserKey(userID)}).Result(); err != nil && err != redis.Nil {
+			log.Printf("[ConnectionLimiter] Redis error decrementing user counter: %v", err)
+		}
+	}
+}
+
+// GetCounts returns the current connection counts for a given IP and user
+func (l *ConnectionLimiter) GetCounts(ctx context.Context, ip string, userID uuid.UUID) (ipCount, userCount int64) {
+	if l.redis == nil {
+		return 0, 0
+	}
+
+	if l.config.MaxConnectionsPerIP > 0 {
+		if count, err := l.redis.Get(ctx, l.IPKey(ip)).Int64(); err == nil {
+			ipCount = count
+		}
+	}
+	if l.config.MaxConnectionsPerUser > 0 {
+		if count, err := l.redis.Get(ctx, l.UserKey(userID)).Int64(); err == nil {
+			userCount = count
+		}
+	}
+	return
+}
+
+// ExtractClientIP extracts the real client IP from a Fiber websocket.Conn.
+// It checks X-Forwarded-For and X-Real-IP headers first (for proxied requests),
+// then falls back to the remote address.
+func ExtractClientIP(conn *websocket.Conn) string {
+	// X-Forwarded-For: first IP in the chain is the original client
+	xff := conn.Headers("X-Forwarded-For")
+	if xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 {
+			ip := strings.TrimSpace(parts[0])
+			if ip != "" {
+				return ip
+			}
+		}
+	}
+
+	// X-Real-IP
+	xri := conn.Headers("X-Real-IP")
+	if xri != "" {
+		return strings.TrimSpace(xri)
+	}
+
+	// Fallback to remote address, stripping port
+	remoteAddr := conn.RemoteAddr().String()
+	if remoteAddr != "" {
+		// Handle IPv6 addresses like [::1]:8080
+		if idx := strings.LastIndex(remoteAddr, ":"); idx != -1 {
+			host := remoteAddr[:idx]
+			if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+				return host[1 : len(host)-1]
+			}
+			return host
+		}
+		return remoteAddr
+	}
+
+	return "unknown"
+}

--- a/backend/internal/websocket/gateway_ratelimit_test.go
+++ b/backend/internal/websocket/gateway_ratelimit_test.go
@@ -1,0 +1,365 @@
+package websocket
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestConnectionLimiterConfig tests the default configuration
+func TestConnectionLimiterConfig(t *testing.T) {
+	cfg := DefaultConnectionLimitConfig()
+
+	if cfg.MaxConnectionsPerIP != 20 {
+		t.Errorf("expected default MaxConnectionsPerIP=20, got %d", cfg.MaxConnectionsPerIP)
+	}
+	if cfg.MaxConnectionsPerUser != 5 {
+		t.Errorf("expected default MaxConnectionsPerUser=5, got %d", cfg.MaxConnectionsPerUser)
+	}
+	if cfg.ConnectionTTL != 10*time.Minute {
+		t.Errorf("expected default ConnectionTTL=10m, got %v", cfg.ConnectionTTL)
+	}
+	if !cfg.Enabled {
+		t.Error("expected Enabled=true by default")
+	}
+}
+
+// TestConnectionLimiterIPKey tests the Redis key generation for IP-based keys
+func TestConnectionLimiterIPKey(t *testing.T) {
+	cfg := DefaultConnectionLimitConfig()
+	limiter := NewConnectionLimiter(nil, cfg)
+
+	tests := []struct {
+		ip       string
+		expected string
+	}{
+		{"192.168.1.1", "hearth:ws:conn:ip:192.168.1.1"},
+		{"10.0.0.1", "hearth:ws:conn:ip:10.0.0.1"},
+		{"::1", "hearth:ws:conn:ip:::1"},
+	}
+
+	for _, tc := range tests {
+		got := limiter.IPKey(tc.ip)
+		if got != tc.expected {
+			t.Errorf("IPKey(%q) = %q, want %q", tc.ip, got, tc.expected)
+		}
+	}
+}
+
+// TestConnectionLimiterUserKey tests the Redis key generation for user-based keys
+func TestConnectionLimiterUserKey(t *testing.T) {
+	cfg := DefaultConnectionLimitConfig()
+	limiter := NewConnectionLimiter(nil, cfg)
+
+	userID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	expected := "hearth:ws:conn:user:123e4567-e89b-12d3-a456-426614174000"
+
+	got := limiter.UserKey(userID)
+	if got != expected {
+		t.Errorf("UserKey() = %q, want %q", got, expected)
+	}
+}
+
+// TestConnectionLimiterCheckDisabled tests that check passes when limiter is disabled
+func TestConnectionLimiterCheckDisabled(t *testing.T) {
+	cfg := &ConnectionLimitConfig{Enabled: false, MaxConnectionsPerIP: 1}
+	limiter := NewConnectionLimiter(nil, cfg)
+
+	userID := uuid.New()
+	result := limiter.check(context.Background(), "192.168.1.1", userID)
+
+	if !result.Allowed {
+		t.Error("expected check to pass when limiter is disabled")
+	}
+}
+
+// TestConnectionLimiterCheckNilRedis tests that check passes when Redis is nil
+func TestConnectionLimiterCheckNilRedis(t *testing.T) {
+	cfg := DefaultConnectionLimitConfig()
+	limiter := NewConnectionLimiter(nil, cfg) // nil Redis client
+
+	userID := uuid.New()
+	result := limiter.check(context.Background(), "192.168.1.1", userID)
+
+	// Should fail open (allow) when Redis is unavailable
+	if !result.Allowed {
+		t.Error("expected check to pass when Redis is nil (fail-open)")
+	}
+}
+
+// TestConnectionLimiterCheckIPLimit tests per-IP connection limit enforcement
+func TestConnectionLimiterCheckIPLimit(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	cfg := &ConnectionLimitConfig{
+		Enabled:              true,
+		MaxConnectionsPerIP:  3,
+		MaxConnectionsPerUser: 0, // unlimited
+		ConnectionTTL:        10 * time.Minute,
+	}
+
+	limiter := NewConnectionLimiter(redis.NewClient(&redis.Options{Addr: s.Addr()}), cfg)
+	ctx := context.Background()
+	ip := "192.168.1.100"
+	userID := uuid.New()
+
+	// First 3 connections should be allowed (check then increment)
+	for i := 0; i < 3; i++ {
+		result := limiter.check(ctx, ip, userID)
+		if !result.Allowed {
+			t.Errorf("connection %d: expected allowed, got rejected: %s", i+1, result.Reason)
+		}
+		// After successful check, caller would increment
+		limiter.Increment(ctx, ip, userID)
+	}
+
+	// 4th connection should be rejected (check shows 3 >= limit)
+	result := limiter.check(ctx, ip, userID)
+	if result.Allowed {
+		t.Error("expected 4th connection to be rejected due to IP limit")
+	}
+	if result.Code != 4409 {
+		t.Errorf("expected close code 4409, got %d", result.Code)
+	}
+}
+
+// TestConnectionLimiterCheckUserLimit tests per-user connection limit enforcement
+func TestConnectionLimiterCheckUserLimit(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	cfg := &ConnectionLimitConfig{
+		Enabled:              true,
+		MaxConnectionsPerIP:  0, // unlimited
+		MaxConnectionsPerUser: 2,
+		ConnectionTTL:        10 * time.Minute,
+	}
+
+	limiter := NewConnectionLimiter(redis.NewClient(&redis.Options{Addr: s.Addr()}), cfg)
+	ctx := context.Background()
+	userID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+	// First 2 connections from different IPs should be allowed (check then increment)
+	for i := 0; i < 2; i++ {
+		ip := "192.168.1." + string(rune('A'+i)) // different IPs
+		result := limiter.check(ctx, ip, userID)
+		if !result.Allowed {
+			t.Errorf("connection %d: expected allowed, got rejected: %s", i+1, result.Reason)
+		}
+		// After successful check, caller would increment
+		limiter.Increment(ctx, ip, userID)
+	}
+
+	// 3rd connection from different IP should be rejected due to user limit
+	result := limiter.check(ctx, "192.168.1.99", userID)
+	if result.Allowed {
+		t.Error("expected 3rd connection to be rejected due to user limit")
+	}
+}
+
+// TestConnectionLimiterIncrementDecrement tests counter increment and decrement
+func TestConnectionLimiterIncrementDecrement(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	cfg := &ConnectionLimitConfig{
+		Enabled:            true,
+		MaxConnectionsPerIP: 10,
+		MaxConnectionsPerUser: 10,
+		ConnectionTTL:      10 * time.Minute,
+	}
+
+	redisClient := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	limiter := NewConnectionLimiter(redisClient, cfg)
+	ctx := context.Background()
+	ip := "10.0.0.1"
+	userID := uuid.New()
+
+	// Initial counts should be 0
+	ipCount, userCount := limiter.GetCounts(ctx, ip, userID)
+	if ipCount != 0 || userCount != 0 {
+		t.Errorf("expected initial counts (0, 0), got (%d, %d)", ipCount, userCount)
+	}
+
+	// Increment
+	limiter.Increment(ctx, ip, userID)
+
+	ipCount, userCount = limiter.GetCounts(ctx, ip, userID)
+	if ipCount != 1 || userCount != 1 {
+		t.Errorf("expected counts (1, 1), got (%d, %d)", ipCount, userCount)
+	}
+
+	// Increment again
+	limiter.Increment(ctx, ip, userID)
+
+	ipCount, userCount = limiter.GetCounts(ctx, ip, userID)
+	if ipCount != 2 || userCount != 2 {
+		t.Errorf("expected counts (2, 2), got (%d, %d)", ipCount, userCount)
+	}
+
+	// Decrement
+	limiter.Decrement(ctx, ip, userID)
+
+	ipCount, userCount = limiter.GetCounts(ctx, ip, userID)
+	if ipCount != 1 || userCount != 1 {
+		t.Errorf("expected counts (1, 1) after decrement, got (%d, %d)", ipCount, userCount)
+	}
+}
+
+// TestConnectionLimiterDecrementToZero tests that counters don't go negative
+func TestConnectionLimiterDecrementToZero(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	cfg := &ConnectionLimitConfig{
+		Enabled:            true,
+		MaxConnectionsPerIP: 10,
+		MaxConnectionsPerUser: 10,
+		ConnectionTTL:      10 * time.Minute,
+	}
+
+	redisClient := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	limiter := NewConnectionLimiter(redisClient, cfg)
+	ctx := context.Background()
+	ip := "10.0.0.1"
+	userID := uuid.New()
+
+	// Decrement without prior increment (baseline is 0)
+	limiter.Decrement(ctx, ip, userID)
+
+	// Should not go negative
+	ipCount, _ := limiter.GetCounts(ctx, ip, userID)
+	if ipCount < 0 {
+		t.Errorf("expected count >= 0, got %d", ipCount)
+	}
+}
+
+// TestConnectionLimiterGetCountsNilRedis tests GetCounts with nil Redis
+func TestConnectionLimiterGetCountsNilRedis(t *testing.T) {
+	cfg := DefaultConnectionLimitConfig()
+	limiter := NewConnectionLimiter(nil, cfg)
+
+	ipCount, userCount := limiter.GetCounts(context.Background(), "192.168.1.1", uuid.New())
+	if ipCount != 0 || userCount != 0 {
+		t.Errorf("expected (0, 0) with nil Redis, got (%d, %d)", ipCount, userCount)
+	}
+}
+
+// TestConnectionLimiterCheckIPBeforeUser tests that IP check happens before user check
+func TestConnectionLimiterCheckIPBeforeUser(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	cfg := &ConnectionLimitConfig{
+		Enabled:            true,
+		MaxConnectionsPerIP: 2, // IP limit reached first
+		MaxConnectionsPerUser: 1,
+		ConnectionTTL:      10 * time.Minute,
+	}
+
+	limiter := NewConnectionLimiter(redis.NewClient(&redis.Options{Addr: s.Addr()}), cfg)
+	ctx := context.Background()
+	ip := "192.168.1.50"
+	userID := uuid.New()
+
+	// Use up the IP limit
+	limiter.Increment(ctx, ip, userID)
+	limiter.Increment(ctx, ip, userID)
+
+	// Next connection should be rejected by IP limit, not user limit
+	result := limiter.check(ctx, ip, userID)
+	if result.Allowed {
+		t.Error("expected connection to be rejected")
+	}
+
+	// The reason should mention IP
+	if result.Reason == "" {
+		t.Error("expected a rejection reason")
+	}
+}
+
+// TestExtractClientIP tests IP extraction from websocket connection headers
+func TestExtractClientIP(t *testing.T) {
+	// This test verifies the header parsing logic
+	xff := "203.0.113.50, 70.41.3.18, 150.172.238.178"
+	xri := "203.0.113.50"
+
+	// When XFF is present, should return first IP
+	ip := ipFromHeadersTestHelper("203.0.113.1:8080", xff, "")
+	if ip != "203.0.113.50" {
+		t.Errorf("expected XFF first IP '203.0.113.50', got '%s'", ip)
+	}
+
+	// When XFF is empty but XRI is present
+	ip = ipFromHeadersTestHelper("10.0.0.1:8080", "", xri)
+	if ip != "203.0.113.50" {
+		t.Errorf("expected XRI '203.0.113.50', got '%s'", ip)
+	}
+
+	// Fallback to remote addr
+	ip = ipFromHeadersTestHelper("192.168.1.1:12345", "", "")
+	if ip != "192.168.1.1" {
+		t.Errorf("expected remote addr '192.168.1.1', got '%s'", ip)
+	}
+
+	// IPv6
+	ip = ipFromHeadersTestHelper("[::1]:8080", "", "")
+	if ip != "::1" {
+		t.Errorf("expected IPv6 '::1', got '%s'", ip)
+	}
+}
+
+// ipFromHeadersTestHelper mirrors the ExtractClientIP header parsing logic
+func ipFromHeadersTestHelper(remoteAddr string, xff string, xri string) string {
+	// X-Forwarded-For: first IP in the chain is the original client
+	if xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 {
+			result := strings.TrimSpace(parts[0])
+			if result != "" {
+				return result
+			}
+		}
+	}
+
+	// X-Real-IP
+	if xri != "" {
+		return strings.TrimSpace(xri)
+	}
+
+	// Fallback to remote addr, stripping port
+	if remoteAddr != "" {
+		// Handle IPv6 addresses like [::1]:8080
+		if idx := strings.LastIndex(remoteAddr, ":"); idx != -1 {
+			host := remoteAddr[:idx]
+			if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+				return host[1 : len(host)-1]
+			}
+			return host
+		}
+		return remoteAddr
+	}
+
+	return "unknown"
+}


### PR DESCRIPTION
Implements the HIGH priority task from TASK_QUEUE.md:
- Add per-IP WebSocket connection count limits (configurable, default 20)
- Add per-user WebSocket connection count limits (configurable, default 5)
- Redis-backed for distributed coordination across gateway instances
- ConnectionLimiter struct with check/increment/decrement operations
- Fail-open behavior when Redis is unavailable (to avoid blocking legitimate connections)
- WebSocket close code 4409 (Rate Limited) when limits are exceeded
- ExtractClientIP() helper for X-Forwarded-For / X-Real-IP header parsing
- Unit tests for all limiter logic using miniredis
