### PR TITLE
fix(frontend): replace empty catch blocks with debug logging for media permission denial

### DIFF
--- a/frontend/src/lib/components/AudioSettings.svelte
+++ b/frontend/src/lib/components/AudioSettings.svelte
@@ -26,7 +26,10 @@
     try {
       await navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
         stream.getTracks().forEach(track => track.stop());
-      }).catch(() => {});
+      }).catch(err => {
+        // User denied permission - that's fine, devices will be empty
+        console.debug('Audio permission not granted:', err);
+      });
 
       const devices = await navigator.mediaDevices.enumerateDevices();
       audioInputDevices = devices.filter(d => d.kind === 'audioinput');

--- a/frontend/src/lib/components/UserSettings.svelte
+++ b/frontend/src/lib/components/UserSettings.svelte
@@ -68,7 +68,10 @@
       // Request permission first
       await navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then(stream => {
         stream.getTracks().forEach(track => track.stop());
-      }).catch(() => {});
+      }).catch(err => {
+        // User denied permission - that's fine, devices will be empty
+        console.debug('Media permission not granted:', err);
+      });
       
       const devices = await navigator.mediaDevices.enumerateDevices();
       audioInputDevices = devices.filter(d => d.kind === 'audioinput');


### PR DESCRIPTION
Empty catch blocks silently swallow errors. Changed to console.debug to log
permission denial (expected behavior) while still avoiding error propagation.

Files changed:
- AudioSettings.svelte: Media permission catch now logs via console.debug
- UserSettings.svelte: Media permission catch now logs via console.debug
