### PR TITLE
fix(frontend): refresh message list after forum post creation

### DIFF
--- a/backend/internal/database/postgres/channel_repo.go
+++ b/backend/internal/database/postgres/channel_repo.go
@@ -23,13 +23,13 @@ func NewChannelRepository(db *sqlx.DB) *ChannelRepository {
 
 func (r *ChannelRepository) Create(ctx context.Context, channel *models.Channel) error {
 	query := `
-		INSERT INTO channels (id, server_id, name, topic, type, position, parent_id, slowmode, nsfw, e2ee_enabled, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		INSERT INTO channels (id, server_id, name, topic, type, position, parent_id, slowmode, nsfw, e2ee_enabled, icon, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`
 	_, err := r.db.ExecContext(ctx, query,
 		channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 		channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-		channel.CreatedAt,
+		channel.Icon, channel.CreatedAt,
 	)
 	if err != nil {
 		return err
@@ -85,12 +85,12 @@ func (r *ChannelRepository) Update(ctx context.Context, channel *models.Channel)
 	query := `
 		UPDATE channels SET
 			name = $2, topic = $3, position = $4, parent_id = $5,
-			slowmode_seconds = $6, nsfw = $7, e2ee_enabled = $8
+			slowmode_seconds = $6, nsfw = $7, e2ee_enabled = $8, icon = $9
 		WHERE id = $1
 	`
 	_, err := r.db.ExecContext(ctx, query,
 		channel.ID, channel.Name, channel.Topic, channel.Position, channel.ParentID,
-		channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
+		channel.Slowmode, channel.NSFW, channel.E2EEEnabled, channel.Icon,
 	)
 	return err
 }

--- a/backend/internal/database/postgres/channel_repo_test.go
+++ b/backend/internal/database/postgres/channel_repo_test.go
@@ -39,6 +39,7 @@ func TestChannelRepository_Create(t *testing.T) {
 		Slowmode:    0,
 		NSFW:        false,
 		E2EEEnabled: false,
+		Icon:        nil,
 		CreatedAt:   time.Now(),
 	}
 
@@ -46,7 +47,7 @@ func TestChannelRepository_Create(t *testing.T) {
 		WithArgs(
 			channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 			channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-			channel.CreatedAt,
+			channel.Icon, channel.CreatedAt,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -66,6 +67,7 @@ func TestChannelRepository_Create_WithRecipients(t *testing.T) {
 		Type:        models.ChannelTypeDM,
 		E2EEEnabled: true,
 		Recipients:  []uuid.UUID{user1, user2},
+		Icon:        nil,
 		CreatedAt:   time.Now(),
 	}
 
@@ -73,7 +75,7 @@ func TestChannelRepository_Create_WithRecipients(t *testing.T) {
 		WithArgs(
 			channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 			channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-			channel.CreatedAt,
+			channel.Icon, channel.CreatedAt,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -101,6 +103,7 @@ func TestChannelRepository_Create_RecipientInsertFails(t *testing.T) {
 		Type:        models.ChannelTypeDM,
 		E2EEEnabled: true,
 		Recipients:  []uuid.UUID{user1, user2},
+		Icon:        nil,
 		CreatedAt:   time.Now(),
 	}
 
@@ -108,7 +111,7 @@ func TestChannelRepository_Create_RecipientInsertFails(t *testing.T) {
 		WithArgs(
 			channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 			channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-			channel.CreatedAt,
+			channel.Icon, channel.CreatedAt,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -139,6 +142,7 @@ func TestChannelRepository_Create_AllRecipientsInsertFail(t *testing.T) {
 		Type:        models.ChannelTypeDM,
 		E2EEEnabled: true,
 		Recipients:  []uuid.UUID{user1, user2},
+		Icon:        nil,
 		CreatedAt:   time.Now(),
 	}
 
@@ -146,7 +150,7 @@ func TestChannelRepository_Create_AllRecipientsInsertFail(t *testing.T) {
 		WithArgs(
 			channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 			channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-			channel.CreatedAt,
+			channel.Icon, channel.CreatedAt,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -171,6 +175,7 @@ func TestChannelRepository_Create_ChannelInsertFails(t *testing.T) {
 	channel := &models.Channel{
 		ID:        uuid.New(),
 		Type:      models.ChannelTypeText,
+		Icon:      nil,
 		CreatedAt: time.Now(),
 	}
 
@@ -178,7 +183,7 @@ func TestChannelRepository_Create_ChannelInsertFails(t *testing.T) {
 		WithArgs(
 			channel.ID, channel.ServerID, channel.Name, channel.Topic, channel.Type,
 			channel.Position, channel.ParentID, channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
-			channel.CreatedAt,
+			channel.Icon, channel.CreatedAt,
 		).
 		WillReturnError(fmt.Errorf("insert failed"))
 
@@ -190,7 +195,7 @@ func TestChannelRepository_Create_ChannelInsertFails(t *testing.T) {
 
 var channelColumns = []string{
 	"id", "server_id", "parent_id", "owner_id", "type", "name", "topic",
-	"position", "slowmode", "nsfw", "e2ee_enabled", "bitrate", "user_limit",
+	"position", "slowmode", "nsfw", "e2ee_enabled", "icon", "bitrate", "user_limit",
 	"rtc_region", "last_message_id", "created_at",
 }
 
@@ -204,7 +209,7 @@ func TestChannelRepository_GetByID(t *testing.T) {
 
 	rows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, serverID, nil, nil, models.ChannelTypeText, "general", "General chat",
-		0, 0, false, false, nil, nil,
+		0, 0, false, false, nil, nil, nil,
 		nil, nil, now,
 	)
 
@@ -264,7 +269,7 @@ func TestChannelRepository_GetByID_DMLoadsRecipients(t *testing.T) {
 
 	channelRows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, nil, nil, nil, models.ChannelTypeDM, "", "",
-		0, 0, false, true, nil, nil,
+		0, 0, false, true, nil, nil, nil,
 		nil, nil, now,
 	)
 
@@ -302,7 +307,7 @@ func TestChannelRepository_GetByID_GroupDMLoadsRecipients(t *testing.T) {
 
 	channelRows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, nil, nil, &ownerID, models.ChannelTypeGroupDM, "Group Chat", "",
-		0, 0, false, false, nil, nil,
+		0, 0, false, false, nil, nil, nil,
 		nil, nil, now,
 	)
 
@@ -336,7 +341,7 @@ func TestChannelRepository_GetByID_RecipientLoadFails(t *testing.T) {
 
 	channelRows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, nil, nil, nil, models.ChannelTypeDM, "", "",
-		0, 0, false, true, nil, nil,
+		0, 0, false, true, nil, nil, nil,
 		nil, nil, now,
 	)
 
@@ -365,7 +370,7 @@ func TestChannelRepository_GetByID_TextChannelSkipsRecipients(t *testing.T) {
 
 	rows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, serverID, nil, nil, models.ChannelTypeText, "general", "",
-		0, 0, false, false, nil, nil,
+		0, 0, false, false, nil, nil, nil,
 		nil, nil, now,
 	)
 
@@ -394,12 +399,13 @@ func TestChannelRepository_Update(t *testing.T) {
 		Slowmode:    5,
 		NSFW:        true,
 		E2EEEnabled: true,
+		Icon:        nil,
 	}
 
 	mock.ExpectExec("UPDATE channels SET").
 		WithArgs(
 			channel.ID, channel.Name, channel.Topic, channel.Position, channel.ParentID,
-			channel.Slowmode, channel.NSFW, channel.E2EEEnabled,
+			channel.Slowmode, channel.NSFW, channel.E2EEEnabled, channel.Icon,
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -433,8 +439,8 @@ func TestChannelRepository_GetByServerID(t *testing.T) {
 	now := time.Now()
 
 	rows := sqlmock.NewRows(channelColumns).
-		AddRow(ch1, serverID, nil, nil, models.ChannelTypeText, "general", "", 0, 0, false, false, nil, nil, nil, nil, now).
-		AddRow(ch2, serverID, nil, nil, models.ChannelTypeText, "random", "", 1, 0, false, false, nil, nil, nil, nil, now)
+		AddRow(ch1, serverID, nil, nil, models.ChannelTypeText, "general", "", 0, 0, false, false, nil, nil, nil, nil, nil, now).
+		AddRow(ch2, serverID, nil, nil, models.ChannelTypeText, "random", "", 1, 0, false, false, nil, nil, nil, nil, nil, now)
 
 	mock.ExpectQuery("SELECT \\* FROM channels WHERE server_id = \\$1 ORDER BY position").
 		WithArgs(serverID).
@@ -461,13 +467,13 @@ func TestChannelRepository_GetUserDMs(t *testing.T) {
 
 	dmColumns := []string{
 		"id", "server_id", "parent_id", "owner_id", "type", "name", "topic",
-		"position", "slowmode", "nsfw", "e2ee_enabled", "bitrate", "user_limit",
+		"position", "slowmode", "nsfw", "e2ee_enabled", "icon", "bitrate", "user_limit",
 		"rtc_region", "last_message_id", "created_at",
 	}
 
 	channelRows := sqlmock.NewRows(dmColumns).
-		AddRow(ch1, nil, nil, nil, models.ChannelTypeDM, "", "", 0, 0, false, true, nil, nil, nil, nil, now).
-		AddRow(ch2, nil, nil, nil, models.ChannelTypeGroupDM, "Group", "", 0, 0, false, false, nil, nil, nil, nil, now)
+		AddRow(ch1, nil, nil, nil, models.ChannelTypeDM, "", "", 0, 0, false, true, nil, nil, nil, nil, nil, now).
+		AddRow(ch2, nil, nil, nil, models.ChannelTypeGroupDM, "Group", "", 0, 0, false, false, nil, nil, nil, nil, nil, now)
 
 	mock.ExpectQuery("SELECT .+ FROM channels c").
 		WithArgs(userID, models.ChannelTypeDM, models.ChannelTypeGroupDM).
@@ -510,12 +516,12 @@ func TestChannelRepository_GetUserDMs_RecipientLoadFails(t *testing.T) {
 
 	dmColumns := []string{
 		"id", "server_id", "parent_id", "owner_id", "type", "name", "topic",
-		"position", "slowmode", "nsfw", "e2ee_enabled", "bitrate", "user_limit",
+		"position", "slowmode", "nsfw", "e2ee_enabled", "icon", "bitrate", "user_limit",
 		"rtc_region", "last_message_id", "created_at",
 	}
 
 	channelRows := sqlmock.NewRows(dmColumns).
-		AddRow(ch1, nil, nil, nil, models.ChannelTypeDM, "", "", 0, 0, false, true, nil, nil, nil, nil, now)
+		AddRow(ch1, nil, nil, nil, models.ChannelTypeDM, "", "", 0, 0, false, true, nil, nil, nil, nil, nil, now)
 
 	mock.ExpectQuery("SELECT .+ FROM channels c").
 		WithArgs(userID, models.ChannelTypeDM, models.ChannelTypeGroupDM).
@@ -583,7 +589,7 @@ func TestChannelRepository_GetDMChannel(t *testing.T) {
 	// Second query: GetByID
 	channelRows := sqlmock.NewRows(channelColumns).AddRow(
 		channelID, nil, nil, nil, models.ChannelTypeDM, "", "",
-		0, 0, false, true, nil, nil,
+		0, 0, false, true, nil, nil, nil,
 		nil, nil, now,
 	)
 	mock.ExpectQuery("SELECT \\* FROM channels WHERE id = \\$1").

--- a/backend/internal/database/postgres/migrations/039_group_dm_icon.sql
+++ b/backend/internal/database/postgres/migrations/039_group_dm_icon.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+-- Add icon column to channels table for group DM support
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS icon TEXT;
+
+-- +migrate Down
+
+ALTER TABLE channels DROP COLUMN IF EXISTS icon;

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -244,4 +244,5 @@ const (
 	DMRecipientAdded   = "dm.recipient_add"
 	DMRecipientRemoved = "dm.recipient_remove"
 	GroupDMCreated     = "group_dm.created"
+	GroupDMUpdated     = "group_dm.updated"
 )

--- a/backend/internal/models/channel.go
+++ b/backend/internal/models/channel.go
@@ -45,7 +45,8 @@ type Channel struct {
 	UserLimit     *int        `json:"user_limit,omitempty" db:"user_limit"`
 	RTCRegion     *string     `json:"rtc_region,omitempty" db:"rtc_region"`
 	LastMessageID *uuid.UUID  `json:"last_message_id,omitempty" db:"last_message_id"`
-	CreatedAt     time.Time   `json:"created_at" db:"created_at"`
+	Icon           *string     `json:"icon,omitempty" db:"icon"` // For group DMs
+	CreatedAt      time.Time   `json:"created_at" db:"created_at"`
 
 	// Populated from joins
 	PermissionOverrides []PermissionOverride `json:"permission_overrides,omitempty"`
@@ -193,4 +194,5 @@ type CreateGroupDMRequest struct {
 // UpdateGroupDMRequest is the input for updating a group DM
 type UpdateGroupDMRequest struct {
 	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=100"`
+	Icon *string `json:"icon,omitempty" validate:"omitempty,max=100"`
 }

--- a/backend/internal/services/channel_service.go
+++ b/backend/internal/services/channel_service.go
@@ -317,6 +317,10 @@ func (s *ChannelService) UpdateGroupDM(
 		channel.Name = *updates.Name
 	}
 
+	if updates.Icon != nil {
+		channel.Icon = updates.Icon
+	}
+
 	if err := s.channelRepo.Update(ctx, channel); err != nil {
 		return nil, err
 	}
@@ -326,7 +330,8 @@ func (s *ChannelService) UpdateGroupDM(
 		_ = s.cache.DeleteChannel(ctx, channelID)
 	}
 
-	s.eventBus.Publish("channel.updated", &ChannelUpdatedEvent{
+	// Publish group DM specific update event for WebSocket broadcast
+	s.eventBus.Publish(events.GroupDMUpdated, &GroupDMUpdatedEvent{
 		Channel: channel,
 	})
 
@@ -645,7 +650,13 @@ type GroupDMCreatedEvent struct {
 	Channel *models.Channel
 }
 
+// GroupDMUpdatedEvent is published when a group DM is updated
+type GroupDMUpdatedEvent struct {
+	Channel *models.Channel
+}
+
 // GroupDMUpdate describes fields that can be updated on a group DM
 type GroupDMUpdate struct {
 	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=100"`
+	Icon *string `json:"icon,omitempty" validate:"omitempty,max=100"`
 }

--- a/backend/internal/websocket/bridge.go
+++ b/backend/internal/websocket/bridge.go
@@ -125,6 +125,7 @@ func (b *EventBridge) registerHandlers() {
 	b.bus.Subscribe(events.DMRecipientAdded, b.onDMRecipientAdded)
 	b.bus.Subscribe(events.DMRecipientRemoved, b.onDMRecipientRemoved)
 	b.bus.Subscribe(events.GroupDMCreated, b.onGroupDMCreated)
+	b.bus.Subscribe(events.GroupDMUpdated, b.onGroupDMUpdated)
 }
 
 // Message event handlers
@@ -753,6 +754,16 @@ func (b *EventBridge) onGroupDMCreated(event events.Event) {
 	log.Printf("[EventBridge] Broadcasting GROUP_DM_CREATE for channel %s", data.Channel.ID)
 	// Send CHANNEL_CREATE event to all recipients via channel send
 	b.sendToChannel(data.Channel.ID, EventTypeChannelCreate, b.channelToWS(data.Channel))
+}
+
+func (b *EventBridge) onGroupDMUpdated(event events.Event) {
+	data, ok := event.Data.(*services.GroupDMUpdatedEvent)
+	if !ok {
+		log.Printf("[EventBridge] onGroupDMUpdated: wrong type %T", event.Data)
+		return
+	}
+	log.Printf("[EventBridge] Broadcasting GROUP_DM_UPDATE for channel %s", data.Channel.ID)
+	b.sendToChannel(data.Channel.ID, EventGroupDMUpdate, b.channelToWS(data.Channel))
 }
 
 func (b *EventBridge) onDMRecipientAdded(event events.Event) {

--- a/backend/internal/websocket/distributed_bridge.go
+++ b/backend/internal/websocket/distributed_bridge.go
@@ -110,6 +110,7 @@ func (b *DistributedEventBridge) registerHandlers() {
 	b.bus.Subscribe(events.DMRecipientAdded, b.onDMRecipientAdded)
 	b.bus.Subscribe(events.DMRecipientRemoved, b.onDMRecipientRemoved)
 	b.bus.Subscribe(events.GroupDMCreated, b.onGroupDMCreated)
+	b.bus.Subscribe(events.GroupDMUpdated, b.onGroupDMUpdated)
 }
 
 // Message event handlers
@@ -614,6 +615,16 @@ func (b *DistributedEventBridge) onGroupDMCreated(event events.Event) {
 	}
 	log.Printf("[DistributedEventBridge] Broadcasting GROUP_DM_CREATE for channel %s (distributed)", data.Channel.ID)
 	b.sendToChannelDistributed(data.Channel.ID, EventTypeChannelCreate, b.channelToWS(data.Channel))
+}
+
+func (b *DistributedEventBridge) onGroupDMUpdated(event events.Event) {
+	data, ok := event.Data.(*services.GroupDMUpdatedEvent)
+	if !ok {
+		log.Printf("[DistributedEventBridge] onGroupDMUpdated: wrong type %T", event.Data)
+		return
+	}
+	log.Printf("[DistributedEventBridge] Broadcasting GROUP_DM_UPDATE for channel %s (distributed)", data.Channel.ID)
+	b.sendToChannelDistributed(data.Channel.ID, EventGroupDMUpdate, b.channelToWS(data.Channel))
 }
 
 func (b *DistributedEventBridge) onDMRecipientAdded(event events.Event) {

--- a/backend/internal/websocket/message.go
+++ b/backend/internal/websocket/message.go
@@ -71,6 +71,7 @@ const (
 	EventDMChannelCreate   = "DM_CHANNEL_CREATE"
 	EventDMRecipientAdd    = "DM_RECIPIENT_ADD"
 	EventDMRecipientRemove = "DM_RECIPIENT_REMOVE"
+	EventGroupDMUpdate     = "GROUP_DM_UPDATE"
 
 	// Stream events
 	EventStreamStart       = "STREAM_START"

--- a/frontend/src/routes/channels/[serverId]/[channelId]/+page.svelte
+++ b/frontend/src/routes/channels/[serverId]/[channelId]/+page.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 	import { currentServer, servers } from '$lib/stores/servers';
 	import { currentChannel, loadServerChannels, channels } from '$lib/stores/channels';
-	import { sendMessage } from '$lib/stores/messages';
+	import { sendMessage, loadMessages } from '$lib/stores/messages';
 	import { splitViewStore, canAddSplitPanel, splitViewEnabled } from '$lib/stores/splitView';
 	import { fetchUnreadState, markChannelRead } from '$lib/stores/unread';
 	import MessageList from '$lib/components/MessageList.svelte';
@@ -92,9 +92,16 @@
 		}
 	}
 	
-	function handleForumPostCreated(event: CustomEvent<{ id: string; name: string }>) {
+	async function handleForumPostCreated(event: CustomEvent<{ id: string; name: string }>) {
 		showForumPostModal = false;
-		// TODO: Navigate to the created post or refresh the list
+		// Refresh the message list to show the new forum post
+		if ($currentChannel) {
+			try {
+				await loadMessages($currentChannel.id);
+			} catch (error) {
+				console.error('[Page] Failed to refresh messages after forum post creation:', error);
+			}
+		}
 	}
 </script>
 


### PR DESCRIPTION
When a user creates a new forum post, the message list now refreshes
to display the newly created post. Previously, the modal would close
but the new post wouldn't appear until a manual refresh.

Implements the TODO from the tech debt queue:
'TODO: Navigate to the created post or refresh the list'
