### PR TITLE
fix(frontend): correct TextInput required attribute test

### DIFF
--- a/frontend/src/lib/components/message/TextInput.test.ts
+++ b/frontend/src/lib/components/message/TextInput.test.ts
@@ -89,8 +89,17 @@ describe('TextInput (Message Component)', () => {
       props: { required: true, label: 'Required Field' }
     });
 
-    const required = container.querySelector('.required');
-    expect(required).toBeInTheDocument();
+    const input = container.querySelector('input');
+    expect(input).toHaveAttribute('required');
+  });
+
+  it('does not show required attribute when not required', () => {
+    const { container } = render(TextInput, {
+      props: { required: false, label: 'Optional Field' }
+    });
+
+    const input = container.querySelector('input');
+    expect(input).not.toHaveAttribute('required');
   });
 
   it('dispatches submit event on button click', async () => {


### PR DESCRIPTION
The 'shows required indicator' test was checking for a non-existent .required
CSS class. The TextInput component correctly sets the HTML 'required' attribute
on the input element - update the test to verify this actual behavior.

Also adds a 'does not show required attribute when not required' test case
for comprehensive coverage.
