### PR TITLE
feat(stickers): Advanced Sticker System - premium packs and subscription tiers

### DIFF
--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -493,7 +493,6 @@ func main() {
 
 	// Initialize Sticker service and handler
 	stickerService := services.NewStickerService(repos.Stickers, nil)
-	h.SetStickerHandler(stickerService, serverService, permService)
 	log.Printf("✅ Sticker service initialized")
 
 	// Initialize Soundboard service and handler
@@ -572,6 +571,7 @@ func main() {
 	premiumService := services.NewPremiumService(repos.Premium, repos.Users, repos.Servers, billingService)
 	premiumService.SetEventBus(serviceBus)
 	h.SetPremiumHandler(premiumService, billingService)
+	h.SetStickerHandler(stickerService, serverService, permService, premiumService)
 	log.Printf("✅ Premium & Billing services initialized")
 
 

--- a/backend/internal/api/handlers/handlers.go
+++ b/backend/internal/api/handlers/handlers.go
@@ -80,8 +80,8 @@ func (h *Handlers) SetPollHandler(pollService *services.PollService) {
 }
 
 // SetStickerHandler sets the sticker handler
-func (h *Handlers) SetStickerHandler(stickerService *services.StickerService, serverService *services.ServerService, permService *services.PermissionService) {
-	h.Stickers = NewStickerHandler(stickerService, serverService, permService)
+func (h *Handlers) SetStickerHandler(stickerService *services.StickerService, serverService *services.ServerService, permService *services.PermissionService, premiumService *services.PremiumService) {
+	h.Stickers = NewStickerHandler(stickerService, serverService, permService, premiumService)
 }
 
 // SetAnnouncementHandler sets the announcement handler

--- a/backend/internal/api/handlers/stickers.go
+++ b/backend/internal/api/handlers/stickers.go
@@ -15,6 +15,7 @@ type StickerHandler struct {
 	stickerService *services.StickerService
 	serverService  *services.ServerService
 	permService    *services.PermissionService
+	premiumService *services.PremiumService
 }
 
 // NewStickerHandler creates a new sticker handler
@@ -22,12 +23,25 @@ func NewStickerHandler(
 	stickerService *services.StickerService,
 	serverService *services.ServerService,
 	permService *services.PermissionService,
+	premiumService *services.PremiumService,
 ) *StickerHandler {
 	return &StickerHandler{
 		stickerService: stickerService,
 		serverService:  serverService,
 		permService:    permService,
+		premiumService: premiumService,
 	}
+}
+
+// getUserStickerTier gets the user's sticker tier based on their premium subscription
+func (h *StickerHandler) getUserStickerTier(ctx *fiber.Ctx, userID uuid.UUID) models.StickerPackTier {
+	if h.premiumService != nil {
+		status, err := h.premiumService.GetUserPremiumStatus(ctx.Context(), userID)
+		if err == nil && status != nil {
+			return models.StickerTierFromString(string(status.Tier))
+		}
+	}
+	return models.StickerPackTierFree
 }
 
 // ListGlobalStickers returns all global stickers
@@ -40,7 +54,16 @@ func NewStickerHandler(
 // @Failure 500 {object} fiber.Map "Internal server error"
 // @Router /stickers [get]
 func (h *StickerHandler) ListGlobalStickers(c *fiber.Ctx) error {
-	stickers, err := h.stickerService.GetGlobal(c.Context())
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	userTier := h.getUserStickerTier(c, userID)
+
+	stickers, err := h.stickerService.GetAvailable(c.Context(), nil, userTier)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to get stickers",
@@ -67,6 +90,13 @@ func (h *StickerHandler) ListGlobalStickers(c *fiber.Ctx) error {
 // @Failure 500 {object} fiber.Map "Internal server error"
 // @Router /servers/{id}/stickers [get]
 func (h *StickerHandler) ListServerStickers(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
 	serverID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -74,7 +104,9 @@ func (h *StickerHandler) ListServerStickers(c *fiber.Ctx) error {
 		})
 	}
 
-	stickers, err := h.stickerService.GetByServer(c.Context(), serverID)
+	userTier := h.getUserStickerTier(c, userID)
+
+	stickers, err := h.stickerService.GetAvailable(c.Context(), &serverID, userTier)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to get stickers",
@@ -134,6 +166,7 @@ func (h *StickerHandler) GetSticker(c *fiber.Ctx) error {
 // @Param id path string true "Server ID"
 // @Param name formData string true "Sticker name (2-30 chars)"
 // @Param tags formData string false "Comma-separated tags (max 10)"
+// @Param tier formData string false "Required tier (free, basic, premium)" default("free")
 // @Param image formData file true "Sticker image file (PNG, APNG, GIF, max 512KB, max 100x100px)"
 // @Success 201 {object} models.StickerResponse "Sticker created successfully"
 // @Failure 400 {object} fiber.Map "Invalid request or validation error"
@@ -154,6 +187,15 @@ func (h *StickerHandler) CreateSticker(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "invalid server id",
 		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
 	}
 
 	// Get sticker name
@@ -223,8 +265,12 @@ func (h *StickerHandler) CreateSticker(c *fiber.Ctx) error {
 		})
 	}
 
+	// Parse tier
+	tierStr := c.FormValue("tier")
+	requiredTier := models.StickerTierFromString(tierStr)
+
 	// Create sticker
-	sticker, err := h.stickerService.Create(c.Context(), &serverID, name, tags, file, userID)
+	sticker, err := h.stickerService.CreateWithTier(c.Context(), &serverID, name, tags, file, userID, requiredTier)
 	if err != nil {
 		if err == services.ErrStickerNameRequired {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -244,6 +290,11 @@ func (h *StickerHandler) CreateSticker(c *fiber.Ctx) error {
 		if err == services.ErrStickerFormat {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"error": "invalid image type. Use PNG, APNG, or GIF",
+			})
+		}
+		if err == services.ErrPackTierAccess {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "user tier does not have access to create premium stickers",
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -405,6 +456,512 @@ func (h *StickerHandler) DeleteSticker(c *fiber.Ctx) error {
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to delete sticker",
+		})
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// --- Sticker Pack Endpoints ---
+
+// ListGlobalStickerPacks returns all global sticker packs
+// @Summary List global sticker packs
+// @Description Returns all global sticker packs available to the user
+// @Tags Sticker Packs
+// @Produce json
+// @Success 200 {array} models.StickerPackResponse "List of sticker packs"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /sticker-packs [get]
+func (h *StickerHandler) ListGlobalStickerPacks(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	userTier := h.getUserStickerTier(c, userID)
+
+	packs, err := h.stickerService.GetGlobalPacks(c.Context(), userTier)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to get sticker packs",
+		})
+	}
+
+	response := make([]models.StickerPackResponse, 0, len(packs))
+	for _, p := range packs {
+		response = append(response, p.ToPackResponse())
+	}
+
+	return c.JSON(response)
+}
+
+// GetStickerPack returns a specific sticker pack with its stickers
+// @Summary Get sticker pack
+// @Description Returns a specific sticker pack with all its stickers
+// @Tags Sticker Packs
+// @Produce json
+// @Param id path string true "Pack ID"
+// @Success 200 {object} models.StickerPackResponse "Sticker pack details"
+// @Failure 400 {object} fiber.Map "Invalid pack ID"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "User tier does not have access"
+// @Failure 404 {object} fiber.Map "Pack not found"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /sticker-packs/{id} [get]
+func (h *StickerHandler) GetStickerPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	packID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid pack id",
+		})
+	}
+
+	userTier := h.getUserStickerTier(c, userID)
+
+	pack, err := h.stickerService.GetPackWithStickers(c.Context(), packID, userTier)
+	if err != nil {
+		if err == services.ErrPackNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker pack not found",
+			})
+		}
+		if err == services.ErrPackTierAccess {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "user tier does not have access to this pack",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to get sticker pack",
+		})
+	}
+
+	return c.JSON(pack.ToPackResponse())
+}
+
+// ListServerStickerPacks returns all sticker packs for a server
+// @Summary List server sticker packs
+// @Description Returns all sticker packs for a specific server
+// @Tags Sticker Packs
+// @Produce json
+// @Param id path string true "Server ID"
+// @Success 200 {array} models.StickerPackResponse "List of sticker packs"
+// @Failure 400 {object} fiber.Map "Invalid server ID"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs [get]
+func (h *StickerHandler) ListServerStickerPacks(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	userTier := h.getUserStickerTier(c, userID)
+
+	packs, err := h.stickerService.GetPacksByServer(c.Context(), serverID, userTier)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to get sticker packs",
+		})
+	}
+
+	response := make([]models.StickerPackResponse, 0, len(packs))
+	for _, p := range packs {
+		response = append(response, p.ToPackResponse())
+	}
+
+	return c.JSON(response)
+}
+
+// CreateStickerPack creates a new sticker pack (server admins only)
+// @Summary Create sticker pack
+// @Description Creates a new sticker pack for a server
+// @Tags Sticker Packs
+// @Accept json
+// @Produce json
+// @Param id path string true "Server ID"
+// @Param body body models.CreateStickerPackRequest true "Sticker pack data"
+// @Success 201 {object} models.StickerPackResponse "Sticker pack created"
+// @Failure 400 {object} fiber.Map "Invalid request"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "Missing MANAGE_STICKERS permission"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs [post]
+func (h *StickerHandler) CreateStickerPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
+	}
+
+	var req models.CreateStickerPackRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid request body",
+		})
+	}
+
+	if req.Name == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "pack name is required",
+		})
+	}
+
+	if len(req.Name) < 2 || len(req.Name) > 100 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "pack name must be 2-100 characters",
+		})
+	}
+
+	tier := models.StickerTierFromString(req.Tier)
+	isGlobal := false
+	if req.IsGlobal != nil {
+		isGlobal = *req.IsGlobal
+	}
+
+	pack, err := h.stickerService.CreatePack(
+		c.Context(),
+		req.Name,
+		req.Description,
+		req.IconURL,
+		tier,
+		isGlobal,
+		&serverID,
+		userID,
+	)
+	if err != nil {
+		if err == services.ErrPackNameRequired {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "pack name is required",
+			})
+		}
+		if err == services.ErrPackNameTooLong {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "pack name must be 2-100 characters",
+			})
+		}
+		if err == services.ErrPackTierAccess {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "user tier does not have access to create premium packs",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to create sticker pack",
+		})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(pack.ToPackResponse())
+}
+
+// UpdateStickerPack updates a sticker pack
+// @Summary Update sticker pack
+// @Description Updates a sticker pack's details
+// @Tags Sticker Packs
+// @Accept json
+// @Produce json
+// @Param id path string true "Server ID"
+// @Param packId path string true "Pack ID"
+// @Param body body models.UpdateStickerPackRequest true "Update data"
+// @Success 200 {object} models.StickerPackResponse "Updated pack"
+// @Failure 400 {object} fiber.Map "Invalid request"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "Missing MANAGE_STICKERS permission"
+// @Failure 404 {object} fiber.Map "Pack not found"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs/{packId} [patch]
+func (h *StickerHandler) UpdateStickerPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid pack id",
+		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
+	}
+
+	var req models.UpdateStickerPackRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid request body",
+		})
+	}
+
+	pack, err := h.stickerService.UpdatePack(c.Context(), packID, req.Name, req.Description, req.IconURL, req.IsActive)
+	if err != nil {
+		if err == services.ErrPackNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker pack not found",
+			})
+		}
+		if err == services.ErrPackNameTooLong {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "pack name must be 2-100 characters",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to update sticker pack",
+		})
+	}
+
+	return c.JSON(pack.ToPackResponse())
+}
+
+// DeleteStickerPack deletes a sticker pack
+// @Summary Delete sticker pack
+// @Description Deletes a sticker pack and removes all sticker associations
+// @Tags Sticker Packs
+// @Param id path string true "Server ID"
+// @Param packId path string true "Pack ID"
+// @Success 204 "Pack deleted successfully"
+// @Failure 400 {object} fiber.Map "Invalid ID"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "Missing MANAGE_STICKERS permission"
+// @Failure 404 {object} fiber.Map "Pack not found"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs/{packId} [delete]
+func (h *StickerHandler) DeleteStickerPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid pack id",
+		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
+	}
+
+	err = h.stickerService.DeletePack(c.Context(), packID)
+	if err != nil {
+		if err == services.ErrPackNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker pack not found",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to delete sticker pack",
+		})
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// AddStickerToPack adds a sticker to a pack
+// @Summary Add sticker to pack
+// @Description Adds an existing sticker to a sticker pack
+// @Tags Sticker Packs
+// @Accept json
+// @Produce json
+// @Param id path string true "Server ID"
+// @Param packId path string true "Pack ID"
+// @Param body body models.AddStickerToPackRequest true "Sticker to add"
+// @Success 200 {object} fiber.Map "Sticker added to pack"
+// @Failure 400 {object} fiber.Map "Invalid request"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "Missing MANAGE_STICKERS permission"
+// @Failure 404 {object} fiber.Map "Pack or sticker not found"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs/{packId}/stickers [post]
+func (h *StickerHandler) AddStickerToPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid pack id",
+		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
+	}
+
+	var req models.AddStickerToPackRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid request body",
+		})
+	}
+
+	if req.StickerID == uuid.Nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "sticker_id is required",
+		})
+	}
+
+	err = h.stickerService.AddStickerToPack(c.Context(), packID, req.StickerID, req.Position, req.IsDefault)
+	if err != nil {
+		if err == services.ErrPackNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker pack not found",
+			})
+		}
+		if err == services.ErrStickerNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker not found",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to add sticker to pack",
+		})
+	}
+
+	return c.JSON(fiber.Map{"message": "sticker added to pack"})
+}
+
+// RemoveStickerFromPack removes a sticker from a pack
+// @Summary Remove sticker from pack
+// @Description Removes a sticker from a sticker pack
+// @Tags Sticker Packs
+// @Param id path string true "Server ID"
+// @Param packId path string true "Pack ID"
+// @Param stickerId path string true "Sticker ID"
+// @Success 204 "Sticker removed from pack"
+// @Failure 400 {object} fiber.Map "Invalid ID"
+// @Failure 401 {object} fiber.Map "Unauthorized"
+// @Failure 403 {object} fiber.Map "Missing MANAGE_STICKERS permission"
+// @Failure 404 {object} fiber.Map "Pack or sticker not found"
+// @Failure 500 {object} fiber.Map "Internal server error"
+// @Router /servers/{id}/sticker-packs/{packId}/stickers/{stickerId} [delete]
+func (h *StickerHandler) RemoveStickerFromPack(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "unauthorized",
+		})
+	}
+
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid server id",
+		})
+	}
+
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid pack id",
+		})
+	}
+
+	stickerID, err := uuid.Parse(c.Params("stickerId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid sticker id",
+		})
+	}
+
+	// Check MANAGE_STICKERS permission
+	if h.permService != nil {
+		if err := h.permService.RequirePermission(c.Context(), serverID, userID, models.PermManageStickers); err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "missing MANAGE_STICKERS permission",
+			})
+		}
+	}
+
+	err = h.stickerService.RemoveStickerFromPack(c.Context(), packID, stickerID)
+	if err != nil {
+		if err == services.ErrPackNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "sticker pack not found",
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to remove sticker from pack",
 		})
 	}
 

--- a/backend/internal/api/handlers/stickers_test.go
+++ b/backend/internal/api/handlers/stickers_test.go
@@ -18,12 +18,16 @@ import (
 
 // mockStickerRepo is a mock implementation of StickerRepository for testing
 type mockStickerRepo struct {
-	stickers map[uuid.UUID]*models.Sticker
+	stickers       map[uuid.UUID]*models.Sticker
+	packs          map[uuid.UUID]*models.StickerPack
+	packStickers   map[uuid.UUID]map[uuid.UUID]*models.PackSticker
 }
 
 func newMockStickerRepo() *mockStickerRepo {
 	return &mockStickerRepo{
-		stickers: make(map[uuid.UUID]*models.Sticker),
+		stickers:     make(map[uuid.UUID]*models.Sticker),
+		packs:        make(map[uuid.UUID]*models.StickerPack),
+		packStickers: make(map[uuid.UUID]map[uuid.UUID]*models.PackSticker),
 	}
 }
 
@@ -100,6 +104,131 @@ func (m *mockStickerRepo) Search(ctx context.Context, query string, serverID *uu
 			if strings.Contains(strings.ToLower(tag), strings.ToLower(query)) {
 				result = append(result, s)
 				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// Sticker Pack methods
+func (m *mockStickerRepo) CreatePack(ctx context.Context, pack *models.StickerPack) error {
+	m.packs[pack.ID] = pack
+	m.packStickers[pack.ID] = make(map[uuid.UUID]*models.PackSticker)
+	return nil
+}
+
+func (m *mockStickerRepo) GetPackByID(ctx context.Context, id uuid.UUID) (*models.StickerPack, error) {
+	pack, ok := m.packs[id]
+	if !ok {
+		return nil, nil
+	}
+	return pack, nil
+}
+
+func (m *mockStickerRepo) UpdatePack(ctx context.Context, pack *models.StickerPack) error {
+	m.packs[pack.ID] = pack
+	return nil
+}
+
+func (m *mockStickerRepo) DeletePack(ctx context.Context, id uuid.UUID) error {
+	delete(m.packs, id)
+	delete(m.packStickers, id)
+	return nil
+}
+
+func (m *mockStickerRepo) GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.ServerID != nil && *p.ServerID == serverID {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetGlobalPacks(ctx context.Context) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.IsGlobal {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetPacksByTier(ctx context.Context, tier models.StickerPackTier) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.Tier == tier {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	tierOrder := map[models.StickerPackTier]int{
+		models.StickerPackTierFree:    0,
+		models.StickerPackTierBasic:   1,
+		models.StickerPackTierPremium: 2,
+	}
+	userLevel := tierOrder[userTier]
+
+	for _, p := range m.packs {
+		if !p.IsActive {
+			continue
+		}
+		if p.IsGlobal || (serverID != nil && p.ServerID != nil && *p.ServerID == *serverID) {
+			if tierOrder[p.Tier] <= userLevel {
+				result = append(result, p)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error {
+	if _, ok := m.packStickers[packID]; !ok {
+		m.packStickers[packID] = make(map[uuid.UUID]*models.PackSticker)
+	}
+	m.packStickers[packID][stickerID] = &models.PackSticker{
+		ID:        uuid.New(),
+		PackID:    packID,
+		StickerID: stickerID,
+		Position:  position,
+		IsDefault: isDefault,
+	}
+	return nil
+}
+
+func (m *mockStickerRepo) RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error {
+	if pack, ok := m.packStickers[packID]; ok {
+		delete(pack, stickerID)
+	}
+	return nil
+}
+
+func (m *mockStickerRepo) GetStickersInPack(ctx context.Context, packID uuid.UUID) ([]*models.Sticker, error) {
+	stickerIDs, ok := m.packStickers[packID]
+	if !ok {
+		return nil, nil
+	}
+	var result []*models.Sticker
+	for stickerID := range stickerIDs {
+		if sticker, ok := m.stickers[stickerID]; ok {
+			result = append(result, sticker)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetPacksContainingSticker(ctx context.Context, stickerID uuid.UUID) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for packID, stickers := range m.packStickers {
+		if _, ok := stickers[stickerID]; ok {
+			if pack, ok := m.packs[packID]; ok {
+				result = append(result, pack)
 			}
 		}
 	}
@@ -331,13 +460,13 @@ func TestStickerService_GetAvailable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Without server context - only global
-	stickers, err := service.GetAvailable(ctx, nil)
+	stickers, err := service.GetAvailable(ctx, nil, models.StickerPackTierFree)
 	require.NoError(t, err)
 	assert.Len(t, stickers, 1)
 	assert.Equal(t, "GlobalSticker", stickers[0].Name)
 
 	// With server context - global + server
-	stickers, err = service.GetAvailable(ctx, &serverID)
+	stickers, err = service.GetAvailable(ctx, &serverID, models.StickerPackTierFree)
 	require.NoError(t, err)
 	assert.Len(t, stickers, 2)
 }

--- a/backend/internal/database/postgres/migrations/041_sticker_packs.sql
+++ b/backend/internal/database/postgres/migrations/041_sticker_packs.sql
@@ -1,0 +1,80 @@
+-- Migration 041: Advanced Sticker System - Premium Sticker Packs
+-- Adds sticker pack system with tiers (Free, Premium) linked to subscription tiers
+
+-- Create sticker pack tier enum
+CREATE TYPE sticker_pack_tier AS ENUM ('free', 'basic', 'premium');
+
+-- Create sticker packs table
+CREATE TABLE sticker_packs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    icon_url VARCHAR(512),
+    tier sticker_pack_tier NOT NULL DEFAULT 'free',
+    sticker_count INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    is_global BOOLEAN NOT NULL DEFAULT true,
+    server_id UUID REFERENCES servers(id) ON DELETE CASCADE,
+    created_by UUID REFERENCES users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create pack_stickers join table (many-to-many relationship)
+CREATE TABLE pack_stickers (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    pack_id UUID NOT NULL REFERENCES sticker_packs(id) ON DELETE CASCADE,
+    sticker_id UUID NOT NULL REFERENCES stickers(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL DEFAULT 0,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(pack_id, sticker_id)
+);
+
+-- Add required_tier column to stickers (for premium stickers in global packs)
+ALTER TABLE stickers ADD COLUMN IF NOT EXISTS required_tier sticker_pack_tier NOT NULL DEFAULT 'free';
+
+-- Indexes for sticker pack queries
+CREATE INDEX idx_sticker_packs_tier ON sticker_packs(tier);
+CREATE INDEX idx_sticker_packs_server ON sticker_packs(server_id) WHERE server_id IS NOT NULL;
+CREATE INDEX idx_sticker_packs_global ON sticker_packs(is_global) WHERE is_global = true;
+CREATE INDEX idx_sticker_packs_active ON sticker_packs(is_active) WHERE is_active = true;
+
+-- Indexes for pack_stickers
+CREATE INDEX idx_pack_stickers_pack ON pack_stickers(pack_id);
+CREATE INDEX idx_pack_stickers_sticker ON pack_stickers(sticker_id);
+
+-- Index for sticker required_tier
+CREATE INDEX idx_stickers_required_tier ON stickers(required_tier);
+
+-- Insert default free sticker pack
+INSERT INTO sticker_packs (id, name, description, tier, sticker_count, is_active, is_global, created_by)
+VALUES (
+    '00000000-0000-0000-0000-000000000001',
+    'Default Pack',
+    'The default free sticker pack available to all users',
+    'free',
+    0,
+    true,
+    true,
+    NULL
+) ON CONFLICT DO NOTHING;
+
+-- Function to update sticker_count on pack
+CREATE OR REPLACE FUNCTION update_pack_sticker_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        UPDATE sticker_packs SET sticker_count = sticker_count + 1 WHERE id = NEW.pack_id;
+    ELSIF TG_OP = 'DELETE' THEN
+        UPDATE sticker_packs SET sticker_count = sticker_count - 1 WHERE id = OLD.pack_id;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-update sticker count on pack
+DROP TRIGGER IF EXISTS trg_update_pack_sticker_count ON pack_stickers;
+CREATE TRIGGER trg_update_pack_sticker_count
+AFTER INSERT OR DELETE ON pack_stickers
+FOR EACH ROW EXECUTE FUNCTION update_pack_sticker_count();

--- a/backend/internal/database/postgres/sticker_repo.go
+++ b/backend/internal/database/postgres/sticker_repo.go
@@ -23,6 +23,22 @@ type StickerRepository interface {
 	GetGlobal(ctx context.Context) ([]*models.Sticker, error)
 	GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]*models.Sticker, error)
 	Search(ctx context.Context, query string, serverID *uuid.UUID) ([]*models.Sticker, error)
+
+	// Sticker Pack operations
+	CreatePack(ctx context.Context, pack *models.StickerPack) error
+	GetPackByID(ctx context.Context, id uuid.UUID) (*models.StickerPack, error)
+	UpdatePack(ctx context.Context, pack *models.StickerPack) error
+	DeletePack(ctx context.Context, id uuid.UUID) error
+	GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.StickerPack, error)
+	GetGlobalPacks(ctx context.Context) ([]*models.StickerPack, error)
+	GetPacksByTier(ctx context.Context, tier models.StickerPackTier) ([]*models.StickerPack, error)
+	GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error)
+
+	// Pack-Sticker relationship operations
+	AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error
+	RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error
+	GetStickersInPack(ctx context.Context, packID uuid.UUID) ([]*models.Sticker, error)
+	GetPacksContainingSticker(ctx context.Context, stickerID uuid.UUID) ([]*models.StickerPack, error)
 }
 
 type stickerRepo struct {
@@ -36,8 +52,8 @@ func NewStickerRepository(db *sql.DB) StickerRepository {
 
 func (r *stickerRepo) Create(ctx context.Context, sticker *models.Sticker) error {
 	query := `
-		INSERT INTO stickers (id, server_id, name, tags, url, format, created_by, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO stickers (id, server_id, name, tags, url, format, required_tier, created_by, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 
 	_, err := r.db.ExecContext(ctx, query,
@@ -47,6 +63,7 @@ func (r *stickerRepo) Create(ctx context.Context, sticker *models.Sticker) error
 		pq.Array(sticker.Tags),
 		sticker.URL,
 		sticker.Format,
+		sticker.RequiredTier,
 		sticker.CreatedBy,
 		sticker.CreatedAt,
 	)
@@ -56,7 +73,7 @@ func (r *stickerRepo) Create(ctx context.Context, sticker *models.Sticker) error
 func (r *stickerRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Sticker, error) {
 	var sticker models.Sticker
 	query := `
-		SELECT id, server_id, name, tags, url, format, created_by, created_at
+		SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 		FROM stickers
 		WHERE id = $1
 	`
@@ -68,6 +85,7 @@ func (r *stickerRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Sticke
 		pq.Array(&sticker.Tags),
 		&sticker.URL,
 		&sticker.Format,
+		&sticker.RequiredTier,
 		&sticker.CreatedBy,
 		&sticker.CreatedAt,
 	)
@@ -83,7 +101,7 @@ func (r *stickerRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Sticke
 func (r *stickerRepo) Update(ctx context.Context, sticker *models.Sticker) error {
 	query := `
 		UPDATE stickers
-		SET name = $2, tags = $3
+		SET name = $2, tags = $3, required_tier = $4
 		WHERE id = $1
 	`
 
@@ -91,6 +109,7 @@ func (r *stickerRepo) Update(ctx context.Context, sticker *models.Sticker) error
 		sticker.ID,
 		sticker.Name,
 		pq.Array(sticker.Tags),
+		sticker.RequiredTier,
 	)
 	if err != nil {
 		return err
@@ -124,7 +143,7 @@ func (r *stickerRepo) Delete(ctx context.Context, id uuid.UUID) error {
 
 func (r *stickerRepo) GetByServer(ctx context.Context, serverID uuid.UUID) ([]*models.Sticker, error) {
 	query := `
-		SELECT id, server_id, name, tags, url, format, created_by, created_at
+		SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 		FROM stickers
 		WHERE server_id = $1
 		ORDER BY created_at ASC
@@ -146,6 +165,7 @@ func (r *stickerRepo) GetByServer(ctx context.Context, serverID uuid.UUID) ([]*m
 			pq.Array(&sticker.Tags),
 			&sticker.URL,
 			&sticker.Format,
+			&sticker.RequiredTier,
 			&sticker.CreatedBy,
 			&sticker.CreatedAt,
 		)
@@ -159,7 +179,7 @@ func (r *stickerRepo) GetByServer(ctx context.Context, serverID uuid.UUID) ([]*m
 
 func (r *stickerRepo) GetGlobal(ctx context.Context) ([]*models.Sticker, error) {
 	query := `
-		SELECT id, server_id, name, tags, url, format, created_by, created_at
+		SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 		FROM stickers
 		WHERE server_id IS NULL
 		ORDER BY created_at ASC
@@ -181,6 +201,7 @@ func (r *stickerRepo) GetGlobal(ctx context.Context) ([]*models.Sticker, error) 
 			pq.Array(&sticker.Tags),
 			&sticker.URL,
 			&sticker.Format,
+			&sticker.RequiredTier,
 			&sticker.CreatedBy,
 			&sticker.CreatedAt,
 		)
@@ -195,7 +216,7 @@ func (r *stickerRepo) GetGlobal(ctx context.Context) ([]*models.Sticker, error) 
 func (r *stickerRepo) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]*models.Sticker, error) {
 	// Get global stickers
 	globalQuery := `
-		SELECT id, server_id, name, tags, url, format, created_by, created_at
+		SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 		FROM stickers
 		WHERE server_id IS NULL
 		ORDER BY created_at ASC
@@ -217,6 +238,7 @@ func (r *stickerRepo) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]
 			pq.Array(&sticker.Tags),
 			&sticker.URL,
 			&sticker.Format,
+			&sticker.RequiredTier,
 			&sticker.CreatedBy,
 			&sticker.CreatedAt,
 		)
@@ -229,7 +251,7 @@ func (r *stickerRepo) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]
 	// If serverID is provided, also get server-specific stickers
 	if serverID != nil {
 		serverQuery := `
-			SELECT id, server_id, name, tags, url, format, created_by, created_at
+			SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 			FROM stickers
 			WHERE server_id = $1
 			ORDER BY created_at ASC
@@ -250,6 +272,7 @@ func (r *stickerRepo) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]
 				pq.Array(&sticker.Tags),
 				&sticker.URL,
 				&sticker.Format,
+				&sticker.RequiredTier,
 				&sticker.CreatedBy,
 				&sticker.CreatedAt,
 			)
@@ -265,7 +288,7 @@ func (r *stickerRepo) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]
 
 func (r *stickerRepo) Search(ctx context.Context, query string, serverID *uuid.UUID) ([]*models.Sticker, error) {
 	searchQuery := `
-		SELECT id, server_id, name, tags, url, format, created_by, created_at
+		SELECT id, server_id, name, tags, url, format, required_tier, created_by, created_at
 		FROM stickers
 		WHERE (
 			name ILIKE $1
@@ -297,6 +320,7 @@ func (r *stickerRepo) Search(ctx context.Context, query string, serverID *uuid.U
 			pq.Array(&sticker.Tags),
 			&sticker.URL,
 			&sticker.Format,
+			&sticker.RequiredTier,
 			&sticker.CreatedBy,
 			&sticker.CreatedAt,
 		)
@@ -306,6 +330,419 @@ func (r *stickerRepo) Search(ctx context.Context, query string, serverID *uuid.U
 		stickers = append(stickers, sticker)
 	}
 	return stickers, nil
+}
+
+// CreatePack creates a new sticker pack
+func (r *stickerRepo) CreatePack(ctx context.Context, pack *models.StickerPack) error {
+	query := `
+		INSERT INTO sticker_packs (id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		pack.ID,
+		pack.Name,
+		pack.Description,
+		pack.IconURL,
+		pack.Tier,
+		pack.StickerCount,
+		pack.IsActive,
+		pack.IsGlobal,
+		pack.ServerID,
+		pack.CreatedBy,
+		pack.CreatedAt,
+		pack.UpdatedAt,
+	)
+	return err
+}
+
+// GetPackByID retrieves a sticker pack by ID
+func (r *stickerRepo) GetPackByID(ctx context.Context, id uuid.UUID) (*models.StickerPack, error) {
+	var pack models.StickerPack
+	query := `
+		SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+		FROM sticker_packs
+		WHERE id = $1
+	`
+
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&pack.ID,
+		&pack.Name,
+		&pack.Description,
+		&pack.IconURL,
+		&pack.Tier,
+		&pack.StickerCount,
+		&pack.IsActive,
+		&pack.IsGlobal,
+		&pack.ServerID,
+		&pack.CreatedBy,
+		&pack.CreatedAt,
+		&pack.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pack, nil
+}
+
+// UpdatePack updates a sticker pack
+func (r *stickerRepo) UpdatePack(ctx context.Context, pack *models.StickerPack) error {
+	query := `
+		UPDATE sticker_packs
+		SET name = $2, description = $3, icon_url = $4, is_active = $5, updated_at = NOW()
+		WHERE id = $1
+	`
+
+	result, err := r.db.ExecContext(ctx, query,
+		pack.ID,
+		pack.Name,
+		pack.Description,
+		pack.IconURL,
+		pack.IsActive,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// DeletePack deletes a sticker pack
+func (r *stickerRepo) DeletePack(ctx context.Context, id uuid.UUID) error {
+	query := `DELETE FROM sticker_packs WHERE id = $1`
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// GetPacksByServer retrieves all sticker packs for a server
+func (r *stickerRepo) GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.StickerPack, error) {
+	query := `
+		SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+		FROM sticker_packs
+		WHERE server_id = $1 AND is_active = true
+		ORDER BY created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var packs []*models.StickerPack
+	for rows.Next() {
+		pack := &models.StickerPack{}
+		err := rows.Scan(
+			&pack.ID,
+			&pack.Name,
+			&pack.Description,
+			&pack.IconURL,
+			&pack.Tier,
+			&pack.StickerCount,
+			&pack.IsActive,
+			&pack.IsGlobal,
+			&pack.ServerID,
+			&pack.CreatedBy,
+			&pack.CreatedAt,
+			&pack.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		packs = append(packs, pack)
+	}
+	return packs, nil
+}
+
+// GetGlobalPacks retrieves all global sticker packs
+func (r *stickerRepo) GetGlobalPacks(ctx context.Context) ([]*models.StickerPack, error) {
+	query := `
+		SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+		FROM sticker_packs
+		WHERE is_global = true AND is_active = true
+		ORDER BY tier ASC, created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var packs []*models.StickerPack
+	for rows.Next() {
+		pack := &models.StickerPack{}
+		err := rows.Scan(
+			&pack.ID,
+			&pack.Name,
+			&pack.Description,
+			&pack.IconURL,
+			&pack.Tier,
+			&pack.StickerCount,
+			&pack.IsActive,
+			&pack.IsGlobal,
+			&pack.ServerID,
+			&pack.CreatedBy,
+			&pack.CreatedAt,
+			&pack.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		packs = append(packs, pack)
+	}
+	return packs, nil
+}
+
+// GetPacksByTier retrieves all sticker packs of a specific tier
+func (r *stickerRepo) GetPacksByTier(ctx context.Context, tier models.StickerPackTier) ([]*models.StickerPack, error) {
+	query := `
+		SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+		FROM sticker_packs
+		WHERE tier = $1 AND is_active = true
+		ORDER BY created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, tier)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var packs []*models.StickerPack
+	for rows.Next() {
+		pack := &models.StickerPack{}
+		err := rows.Scan(
+			&pack.ID,
+			&pack.Name,
+			&pack.Description,
+			&pack.IconURL,
+			&pack.Tier,
+			&pack.StickerCount,
+			&pack.IsActive,
+			&pack.IsGlobal,
+			&pack.ServerID,
+			&pack.CreatedBy,
+			&pack.CreatedAt,
+			&pack.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		packs = append(packs, pack)
+	}
+	return packs, nil
+}
+
+// GetAvailablePacks retrieves all packs available to a user based on their tier
+func (r *stickerRepo) GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	// First get global packs that user has access to based on tier
+	tierOrder := map[models.StickerPackTier]int{
+		models.StickerPackTierFree:    0,
+		models.StickerPackTierBasic:   1,
+		models.StickerPackTierPremium: 2,
+	}
+	userTierLevel := tierOrder[userTier]
+
+	globalQuery := `
+		SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+		FROM sticker_packs
+		WHERE is_global = true AND is_active = true
+		ORDER BY tier ASC, created_at ASC
+	`
+
+	globalRows, err := r.db.QueryContext(ctx, globalQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer globalRows.Close()
+
+	var packs []*models.StickerPack
+	for globalRows.Next() {
+		pack := &models.StickerPack{}
+		err := globalRows.Scan(
+			&pack.ID,
+			&pack.Name,
+			&pack.Description,
+			&pack.IconURL,
+			&pack.Tier,
+			&pack.StickerCount,
+			&pack.IsActive,
+			&pack.IsGlobal,
+			&pack.ServerID,
+			&pack.CreatedBy,
+			&pack.CreatedAt,
+			&pack.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		// Filter by tier access
+		if tierOrder[pack.Tier] <= userTierLevel {
+			packs = append(packs, pack)
+		}
+	}
+
+	// If serverID is provided, also get server-specific packs
+	if serverID != nil {
+		serverQuery := `
+			SELECT id, name, description, icon_url, tier, sticker_count, is_active, is_global, server_id, created_by, created_at, updated_at
+			FROM sticker_packs
+			WHERE server_id = $1 AND is_active = true
+			ORDER BY tier ASC, created_at ASC
+		`
+
+		serverRows, err := r.db.QueryContext(ctx, serverQuery, *serverID)
+		if err != nil {
+			return nil, err
+		}
+		defer serverRows.Close()
+
+		for serverRows.Next() {
+			pack := &models.StickerPack{}
+			err := serverRows.Scan(
+				&pack.ID,
+				&pack.Name,
+				&pack.Description,
+				&pack.IconURL,
+				&pack.Tier,
+				&pack.StickerCount,
+				&pack.IsActive,
+				&pack.IsGlobal,
+				&pack.ServerID,
+				&pack.CreatedBy,
+				&pack.CreatedAt,
+				&pack.UpdatedAt,
+			)
+			if err != nil {
+				return nil, err
+			}
+			// Filter by tier access
+			if tierOrder[pack.Tier] <= userTierLevel {
+				packs = append(packs, pack)
+			}
+		}
+	}
+
+	return packs, nil
+}
+
+// AddStickerToPack adds a sticker to a pack
+func (r *stickerRepo) AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error {
+	query := `
+		INSERT INTO pack_stickers (id, pack_id, sticker_id, position, is_default, created_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (pack_id, sticker_id) DO UPDATE SET position = $4, is_default = $5
+	`
+
+	_, err := r.db.ExecContext(ctx, query, uuid.New(), packID, stickerID, position, isDefault)
+	return err
+}
+
+// RemoveStickerFromPack removes a sticker from a pack
+func (r *stickerRepo) RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error {
+	query := `DELETE FROM pack_stickers WHERE pack_id = $1 AND sticker_id = $2`
+	_, err := r.db.ExecContext(ctx, query, packID, stickerID)
+	return err
+}
+
+// GetStickersInPack retrieves all stickers in a pack
+func (r *stickerRepo) GetStickersInPack(ctx context.Context, packID uuid.UUID) ([]*models.Sticker, error) {
+	query := `
+		SELECT s.id, s.server_id, s.name, s.tags, s.url, s.format, s.required_tier, s.created_by, s.created_at
+		FROM stickers s
+		INNER JOIN pack_stickers ps ON s.id = ps.sticker_id
+		WHERE ps.pack_id = $1
+		ORDER BY ps.position ASC, ps.created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, packID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var stickers []*models.Sticker
+	for rows.Next() {
+		sticker := &models.Sticker{}
+		err := rows.Scan(
+			&sticker.ID,
+			&sticker.ServerID,
+			&sticker.Name,
+			pq.Array(&sticker.Tags),
+			&sticker.URL,
+			&sticker.Format,
+			&sticker.RequiredTier,
+			&sticker.CreatedBy,
+			&sticker.CreatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		stickers = append(stickers, sticker)
+	}
+	return stickers, nil
+}
+
+// GetPacksContainingSticker retrieves all packs containing a specific sticker
+func (r *stickerRepo) GetPacksContainingSticker(ctx context.Context, stickerID uuid.UUID) ([]*models.StickerPack, error) {
+	query := `
+		SELECT sp.id, sp.name, sp.description, sp.icon_url, sp.tier, sp.sticker_count, sp.is_active, sp.is_global, sp.server_id, sp.created_by, sp.created_at, sp.updated_at
+		FROM sticker_packs sp
+		INNER JOIN pack_stickers ps ON sp.id = ps.pack_id
+		WHERE ps.sticker_id = $1 AND sp.is_active = true
+		ORDER BY sp.tier ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, stickerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var packs []*models.StickerPack
+	for rows.Next() {
+		pack := &models.StickerPack{}
+		err := rows.Scan(
+			&pack.ID,
+			&pack.Name,
+			&pack.Description,
+			&pack.IconURL,
+			&pack.Tier,
+			&pack.StickerCount,
+			&pack.IsActive,
+			&pack.IsGlobal,
+			&pack.ServerID,
+			&pack.CreatedBy,
+			&pack.CreatedAt,
+			&pack.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		packs = append(packs, pack)
+	}
+	return packs, nil
 }
 
 // Ensure test helpers exist (used by sticker_service_test.go)

--- a/backend/internal/models/sticker.go
+++ b/backend/internal/models/sticker.go
@@ -15,44 +15,127 @@ const (
 	StickerFormatGIF  StickerFormat = "GIF"
 )
 
+// StickerPackTier represents the tier of a sticker pack (maps to subscription tiers)
+type StickerPackTier string
+
+const (
+	StickerPackTierFree    StickerPackTier = "free"
+	StickerPackTierBasic   StickerPackTier = "basic"
+	StickerPackTierPremium StickerPackTier = "premium"
+)
+
 // Sticker represents a sticker in the system
 type Sticker struct {
-	ID        uuid.UUID     `json:"id" db:"id"`
-	ServerID  *uuid.UUID    `json:"server_id,omitempty" db:"server_id"` // nil for global stickers
-	Name      string        `json:"name" db:"name"`
-	Tags      []string      `json:"tags" db:"tags"`
-	URL       string        `json:"url" db:"url"`
-	Format    StickerFormat `json:"format" db:"format"`
-	CreatedBy uuid.UUID     `json:"created_by" db:"created_by"`
-	CreatedAt time.Time     `json:"created_at" db:"created_at"`
+	ID          uuid.UUID       `json:"id" db:"id"`
+	ServerID    *uuid.UUID      `json:"server_id,omitempty" db:"server_id"` // nil for global stickers
+	Name        string          `json:"name" db:"name"`
+	Tags        []string        `json:"tags" db:"tags"`
+	URL         string          `json:"url" db:"url"`
+	Format      StickerFormat   `json:"format" db:"format"`
+	RequiredTier StickerPackTier `json:"required_tier" db:"required_tier"` // Minimum tier to use this sticker
+	CreatedBy   uuid.UUID       `json:"created_by" db:"created_by"`
+	CreatedAt   time.Time       `json:"created_at" db:"created_at"`
+}
+
+// StickerPack represents a collection of stickers
+type StickerPack struct {
+	ID           uuid.UUID       `json:"id" db:"id"`
+	Name         string          `json:"name" db:"name"`
+	Description  *string         `json:"description,omitempty" db:"description"`
+	IconURL      *string         `json:"icon_url,omitempty" db:"icon_url"`
+	Tier         StickerPackTier `json:"tier" db:"tier"`
+	StickerCount int             `json:"sticker_count" db:"sticker_count"`
+	IsActive     bool            `json:"is_active" db:"is_active"`
+	IsGlobal     bool            `json:"is_global" db:"is_global"`
+	ServerID     *uuid.UUID      `json:"server_id,omitempty" db:"server_id"`
+	CreatedBy    *uuid.UUID      `json:"created_by,omitempty" db:"created_by"`
+	CreatedAt    time.Time       `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at" db:"updated_at"`
+	Stickers     []*Sticker      `json:"stickers,omitempty"` // Populated when fetching pack with stickers
+}
+
+// PackSticker represents the many-to-many relationship between packs and stickers
+type PackSticker struct {
+	ID        uuid.UUID `json:"id" db:"id"`
+	PackID    uuid.UUID `json:"pack_id" db:"pack_id"`
+	StickerID uuid.UUID `json:"sticker_id" db:"sticker_id"`
+	Position  int       `json:"position" db:"position"`
+	IsDefault bool      `json:"is_default" db:"is_default"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
 }
 
 // StickerResponse is the API response for a sticker
 type StickerResponse struct {
-	ID        string   `json:"id"`
-	ServerID  *string  `json:"guild_id,omitempty"`
-	Name      string   `json:"name"`
-	Tags      []string `json:"tags"`
-	URL       string   `json:"url"`
-	Format    string   `json:"format"`
-	CreatedBy string   `json:"creator_id"`
-	CreatedAt string   `json:"created_at"`
+	ID           string   `json:"id"`
+	ServerID     *string  `json:"guild_id,omitempty"`
+	Name         string   `json:"name"`
+	Tags         []string `json:"tags"`
+	URL          string   `json:"url"`
+	Format       string   `json:"format"`
+	RequiredTier string   `json:"required_tier"`
+	CreatedBy    string   `json:"creator_id"`
+	CreatedAt    string   `json:"created_at"`
+}
+
+// StickerPackResponse is the API response for a sticker pack
+type StickerPackResponse struct {
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	Description  *string              `json:"description,omitempty"`
+	IconURL      *string              `json:"icon_url,omitempty"`
+	Tier         string               `json:"tier"`
+	StickerCount int                  `json:"sticker_count"`
+	IsActive     bool                 `json:"is_active"`
+	IsGlobal     bool                 `json:"is_global"`
+	ServerID     *string              `json:"guild_id,omitempty"`
+	CreatedBy    *string              `json:"creator_id,omitempty"`
+	CreatedAt    string               `json:"created_at"`
+	Stickers     []StickerResponse    `json:"stickers,omitempty"`
 }
 
 // ToResponse converts a Sticker to StickerResponse
 func (s *Sticker) ToResponse() StickerResponse {
 	resp := StickerResponse{
-		ID:        s.ID.String(),
-		Name:      s.Name,
-		Tags:      s.Tags,
-		URL:       s.URL,
-		Format:    string(s.Format),
-		CreatedBy: s.CreatedBy.String(),
-		CreatedAt: s.CreatedAt.Format(time.RFC3339),
+		ID:           s.ID.String(),
+		Name:         s.Name,
+		Tags:         s.Tags,
+		URL:          s.URL,
+		Format:       string(s.Format),
+		RequiredTier: string(s.RequiredTier),
+		CreatedBy:    s.CreatedBy.String(),
+		CreatedAt:    s.CreatedAt.Format(time.RFC3339),
 	}
 	if s.ServerID != nil {
 		serverIDStr := s.ServerID.String()
 		resp.ServerID = &serverIDStr
+	}
+	return resp
+}
+
+// ToPackResponse converts a StickerPack to StickerPackResponse
+func (p *StickerPack) ToPackResponse() StickerPackResponse {
+	resp := StickerPackResponse{
+		ID:           p.ID.String(),
+		Name:         p.Name,
+		Description:  p.Description,
+		IconURL:      p.IconURL,
+		Tier:         string(p.Tier),
+		StickerCount: p.StickerCount,
+		IsActive:     p.IsActive,
+		IsGlobal:     p.IsGlobal,
+		CreatedAt:    p.CreatedAt.Format(time.RFC3339),
+		Stickers:     []StickerResponse{},
+	}
+	if p.ServerID != nil {
+		serverIDStr := p.ServerID.String()
+		resp.ServerID = &serverIDStr
+	}
+	if p.CreatedBy != nil {
+		createdByStr := p.CreatedBy.String()
+		resp.CreatedBy = &createdByStr
+	}
+	for _, s := range p.Stickers {
+		resp.Stickers = append(resp.Stickers, s.ToResponse())
 	}
 	return resp
 }
@@ -67,4 +150,50 @@ type CreateStickerRequest struct {
 type UpdateStickerRequest struct {
 	Name string   `json:"name,omitempty" validate:"omitempty,min=2,max=30"`
 	Tags []string `json:"tags,omitempty" validate:"max=10"`
+}
+
+// CreateStickerPackRequest is the request to create a sticker pack
+type CreateStickerPackRequest struct {
+	Name        string   `json:"name" validate:"required,min=2,max=100"`
+	Description *string  `json:"description,omitempty" validate:"max=500"`
+	IconURL     *string  `json:"icon_url,omitempty"`
+	Tier        string   `json:"tier" validate:"required,oneof=free basic premium"`
+	IsGlobal    *bool   `json:"is_global,omitempty"`
+}
+
+// UpdateStickerPackRequest is the request to update a sticker pack
+type UpdateStickerPackRequest struct {
+	Name        *string `json:"name,omitempty" validate:"omitempty,min=2,max=100"`
+	Description *string `json:"description,omitempty" validate:"max=500"`
+	IconURL     *string `json:"icon_url,omitempty"`
+	IsActive    *bool   `json:"is_active,omitempty"`
+}
+
+// AddStickerToPackRequest is the request to add a sticker to a pack
+type AddStickerToPackRequest struct {
+	StickerID uuid.UUID `json:"sticker_id" validate:"required"`
+	Position  int       `json:"position,omitempty"`
+	IsDefault bool      `json:"is_default,omitempty"`
+}
+
+// StickerTierFromString converts a string to StickerPackTier
+func StickerTierFromString(s string) StickerPackTier {
+	switch s {
+	case "basic":
+		return StickerPackTierBasic
+	case "premium":
+		return StickerPackTierPremium
+	default:
+		return StickerPackTierFree
+	}
+}
+
+// TierMeetsRequirement checks if a user's tier meets the required tier for a sticker/pack
+func TierMeetsRequirement(userTier, requiredTier StickerPackTier) bool {
+	tierOrder := map[StickerPackTier]int{
+		StickerPackTierFree:    0,
+		StickerPackTierBasic:   1,
+		StickerPackTierPremium: 2,
+	}
+	return tierOrder[userTier] >= tierOrder[requiredTier]
 }

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -171,6 +171,22 @@ type StickerRepository interface {
 	GetGlobal(ctx context.Context) ([]*models.Sticker, error)
 	GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]*models.Sticker, error)
 	Search(ctx context.Context, query string, serverID *uuid.UUID) ([]*models.Sticker, error)
+
+	// Sticker Pack operations
+	CreatePack(ctx context.Context, pack *models.StickerPack) error
+	GetPackByID(ctx context.Context, id uuid.UUID) (*models.StickerPack, error)
+	UpdatePack(ctx context.Context, pack *models.StickerPack) error
+	DeletePack(ctx context.Context, id uuid.UUID) error
+	GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.StickerPack, error)
+	GetGlobalPacks(ctx context.Context) ([]*models.StickerPack, error)
+	GetPacksByTier(ctx context.Context, tier models.StickerPackTier) ([]*models.StickerPack, error)
+	GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error)
+
+	// Pack-Sticker relationship operations
+	AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error
+	RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error
+	GetStickersInPack(ctx context.Context, packID uuid.UUID) ([]*models.Sticker, error)
+	GetPacksContainingSticker(ctx context.Context, stickerID uuid.UUID) ([]*models.StickerPack, error)
 }
 
 type QuotaService struct {

--- a/backend/internal/services/sticker_service.go
+++ b/backend/internal/services/sticker_service.go
@@ -21,12 +21,24 @@ var (
 	ErrStickerTooLarge     = errors.New("sticker file too large (max 512KB)")
 	ErrStickerFormat       = errors.New("invalid sticker format (only PNG, APNG, GIF allowed)")
 	ErrStickerDimensions   = errors.New("sticker dimensions too large (max 100x100px)")
+
+	// Sticker Pack errors
+	ErrPackNotFound       = errors.New("sticker pack not found")
+	ErrPackNameRequired   = errors.New("pack name is required")
+	ErrPackNameTooLong    = errors.New("pack name too long (max 100 chars)")
+	ErrPackTierInvalid    = errors.New("invalid pack tier")
+	ErrPackTierRequired   = errors.New("pack tier required")
+	ErrPackNotOwned       = errors.New("user does not own this pack")
+	ErrPackNotGlobal      = errors.New("can only create global packs")
+	ErrPackTierAccess     = errors.New("user tier does not have access to this pack")
+	ErrStickerAlreadyInPack = errors.New("sticker already in pack")
 )
 
 // StickerService handles sticker business logic
 type StickerService struct {
 	stickerRepo StickerRepository
 	storage     *storage.Service
+	premiumRepo PremiumRepository
 }
 
 // NewStickerService creates a new sticker service
@@ -35,6 +47,11 @@ func NewStickerService(stickerRepo StickerRepository, storageService *storage.Se
 		stickerRepo: stickerRepo,
 		storage:     storageService,
 	}
+}
+
+// SetPremiumRepository sets the premium repository for subscription checks
+func (s *StickerService) SetPremiumRepository(premiumRepo PremiumRepository) {
+	s.premiumRepo = premiumRepo
 }
 
 // StickerFileInfo contains sticker upload validation info
@@ -92,6 +109,19 @@ func (s *StickerService) Create(
 	file *multipart.FileHeader,
 	uploadedBy uuid.UUID,
 ) (*models.Sticker, error) {
+	return s.CreateWithTier(ctx, serverID, name, tags, file, uploadedBy, models.StickerPackTierFree)
+}
+
+// CreateWithTier creates a new sticker with a specific tier requirement
+func (s *StickerService) CreateWithTier(
+	ctx context.Context,
+	serverID *uuid.UUID,
+	name string,
+	tags []string,
+	file *multipart.FileHeader,
+	uploadedBy uuid.UUID,
+	requiredTier models.StickerPackTier,
+) (*models.Sticker, error) {
 	if name == "" {
 		return nil, ErrStickerNameRequired
 	}
@@ -121,14 +151,15 @@ func (s *StickerService) Create(
 	format := GetStickerFormatFromContentType(file.Header.Get("Content-Type"))
 
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  serverID,
-		Name:      name,
-		Tags:      tags,
-		URL:       url,
-		Format:    format,
-		CreatedBy: uploadedBy,
-		CreatedAt: time.Now(),
+		ID:           uuid.New(),
+		ServerID:     serverID,
+		Name:         name,
+		Tags:         tags,
+		URL:          url,
+		Format:       format,
+		RequiredTier: requiredTier,
+		CreatedBy:    uploadedBy,
+		CreatedAt:    time.Now(),
 	}
 
 	if err := s.stickerRepo.Create(ctx, sticker); err != nil {
@@ -161,8 +192,20 @@ func (s *StickerService) GetGlobal(ctx context.Context) ([]*models.Sticker, erro
 }
 
 // GetAvailable returns all stickers available to a user (global + server-specific)
-func (s *StickerService) GetAvailable(ctx context.Context, serverID *uuid.UUID) ([]*models.Sticker, error) {
-	return s.stickerRepo.GetAvailable(ctx, serverID)
+func (s *StickerService) GetAvailable(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.Sticker, error) {
+	allStickers, err := s.stickerRepo.GetAvailable(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by tier access
+	var filtered []*models.Sticker
+	for _, sticker := range allStickers {
+		if models.TierMeetsRequirement(userTier, sticker.RequiredTier) {
+			filtered = append(filtered, sticker)
+		}
+	}
+	return filtered, nil
 }
 
 // Update updates a sticker's name and tags
@@ -209,4 +252,240 @@ func (s *StickerService) Delete(ctx context.Context, stickerID uuid.UUID) error 
 // Search searches stickers by name or tags
 func (s *StickerService) Search(ctx context.Context, query string, serverID *uuid.UUID) ([]*models.Sticker, error) {
 	return s.stickerRepo.Search(ctx, query, serverID)
+}
+
+// --- Sticker Pack Operations ---
+
+// CreatePack creates a new sticker pack
+func (s *StickerService) CreatePack(
+	ctx context.Context,
+	name string,
+	description *string,
+	iconURL *string,
+	tier models.StickerPackTier,
+	isGlobal bool,
+	serverID *uuid.UUID,
+	createdBy uuid.UUID,
+) (*models.StickerPack, error) {
+	if name == "" {
+		return nil, ErrPackNameRequired
+	}
+	if len(name) > 100 {
+		return nil, ErrPackNameTooLong
+	}
+
+	// For now, only global packs are supported unless serverID is provided
+	if !isGlobal && serverID == nil {
+		// Default to global pack if no server specified
+		isGlobal = true
+	}
+
+	// Check user tier access for premium packs
+	if tier != models.StickerPackTierFree {
+		if s.premiumRepo != nil {
+			userPremiumTier, err := s.premiumRepo.GetUserPremiumTier(ctx, createdBy)
+			if err != nil || !models.TierMeetsRequirement(models.StickerTierFromString(string(userPremiumTier)), tier) {
+				return nil, ErrPackTierAccess
+			}
+		}
+	}
+
+	pack := &models.StickerPack{
+		ID:           uuid.New(),
+		Name:         name,
+		Description:  description,
+		IconURL:      iconURL,
+		Tier:         tier,
+		StickerCount: 0,
+		IsActive:     true,
+		IsGlobal:     isGlobal,
+		ServerID:     serverID,
+		CreatedBy:    &createdBy,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	if err := s.stickerRepo.CreatePack(ctx, pack); err != nil {
+		return nil, fmt.Errorf("failed to create pack: %w", err)
+	}
+
+	return pack, nil
+}
+
+// GetPack retrieves a sticker pack by ID
+func (s *StickerService) GetPack(ctx context.Context, packID uuid.UUID) (*models.StickerPack, error) {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return nil, err
+	}
+	if pack == nil {
+		return nil, ErrPackNotFound
+	}
+	return pack, nil
+}
+
+// GetPackWithStickers retrieves a pack with all its stickers
+func (s *StickerService) GetPackWithStickers(ctx context.Context, packID uuid.UUID, userTier models.StickerPackTier) (*models.StickerPack, error) {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return nil, err
+	}
+	if pack == nil {
+		return nil, ErrPackNotFound
+	}
+
+	// Check tier access
+	if !models.TierMeetsRequirement(userTier, pack.Tier) {
+		return nil, ErrPackTierAccess
+	}
+
+	// Get stickers
+	stickers, err := s.stickerRepo.GetStickersInPack(ctx, packID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter stickers by user's tier
+	var filteredStickers []*models.Sticker
+	for _, sticker := range stickers {
+		if models.TierMeetsRequirement(userTier, sticker.RequiredTier) {
+			filteredStickers = append(filteredStickers, sticker)
+		}
+	}
+	pack.Stickers = filteredStickers
+
+	return pack, nil
+}
+
+// GetPacksByServer retrieves all packs for a server
+func (s *StickerService) GetPacksByServer(ctx context.Context, serverID uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	packs, err := s.stickerRepo.GetPacksByServer(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by tier access
+	var filtered []*models.StickerPack
+	for _, pack := range packs {
+		if models.TierMeetsRequirement(userTier, pack.Tier) {
+			filtered = append(filtered, pack)
+		}
+	}
+	return filtered, nil
+}
+
+// GetGlobalPacks retrieves all global packs
+func (s *StickerService) GetGlobalPacks(ctx context.Context, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	packs, err := s.stickerRepo.GetGlobalPacks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by tier access
+	var filtered []*models.StickerPack
+	for _, pack := range packs {
+		if models.TierMeetsRequirement(userTier, pack.Tier) {
+			filtered = append(filtered, pack)
+		}
+	}
+	return filtered, nil
+}
+
+// GetAvailablePacks retrieves all packs available to a user
+func (s *StickerService) GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	return s.stickerRepo.GetAvailablePacks(ctx, serverID, userTier)
+}
+
+// UpdatePack updates a sticker pack
+func (s *StickerService) UpdatePack(ctx context.Context, packID uuid.UUID, name *string, description *string, iconURL *string, isActive *bool) (*models.StickerPack, error) {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return nil, err
+	}
+	if pack == nil {
+		return nil, ErrPackNotFound
+	}
+
+	if name != nil {
+		if len(*name) > 100 {
+			return nil, ErrPackNameTooLong
+		}
+		pack.Name = *name
+	}
+	if description != nil {
+		pack.Description = description
+	}
+	if iconURL != nil {
+		pack.IconURL = iconURL
+	}
+	if isActive != nil {
+		pack.IsActive = *isActive
+	}
+
+	if err := s.stickerRepo.UpdatePack(ctx, pack); err != nil {
+		return nil, err
+	}
+
+	return pack, nil
+}
+
+// DeletePack deletes a sticker pack
+func (s *StickerService) DeletePack(ctx context.Context, packID uuid.UUID) error {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return err
+	}
+	if pack == nil {
+		return ErrPackNotFound
+	}
+
+	return s.stickerRepo.DeletePack(ctx, packID)
+}
+
+// AddStickerToPack adds a sticker to a pack
+func (s *StickerService) AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return err
+	}
+	if pack == nil {
+		return ErrPackNotFound
+	}
+
+	sticker, err := s.stickerRepo.GetByID(ctx, stickerID)
+	if err != nil {
+		return err
+	}
+	if sticker == nil {
+		return ErrStickerNotFound
+	}
+
+	return s.stickerRepo.AddStickerToPack(ctx, packID, stickerID, position, isDefault)
+}
+
+// RemoveStickerFromPack removes a sticker from a pack
+func (s *StickerService) RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error {
+	pack, err := s.stickerRepo.GetPackByID(ctx, packID)
+	if err != nil {
+		return err
+	}
+	if pack == nil {
+		return ErrPackNotFound
+	}
+
+	return s.stickerRepo.RemoveStickerFromPack(ctx, packID, stickerID)
+}
+
+// GetUserTierFromPremiumRepo gets the user's premium tier from the premium repository
+func (s *StickerService) GetUserTierFromPremiumRepo(ctx context.Context, userID uuid.UUID) (models.StickerPackTier, error) {
+	if s.premiumRepo == nil {
+		return models.StickerPackTierFree, nil
+	}
+
+	tier, err := s.premiumRepo.GetUserPremiumTier(ctx, userID)
+	if err != nil {
+		return models.StickerPackTierFree, nil
+	}
+
+	return models.StickerTierFromString(string(tier)), nil
 }

--- a/backend/internal/services/sticker_service_test.go
+++ b/backend/internal/services/sticker_service_test.go
@@ -13,12 +13,16 @@ import (
 
 // mockStickerRepo is a mock implementation of StickerRepository for testing
 type mockStickerRepo struct {
-	stickers map[uuid.UUID]*models.Sticker
+	stickers       map[uuid.UUID]*models.Sticker
+	packs          map[uuid.UUID]*models.StickerPack
+	packStickers   map[uuid.UUID]map[uuid.UUID]*models.PackSticker
 }
 
 func newMockStickerRepo() *mockStickerRepo {
 	return &mockStickerRepo{
-		stickers: make(map[uuid.UUID]*models.Sticker),
+		stickers:     make(map[uuid.UUID]*models.Sticker),
+		packs:        make(map[uuid.UUID]*models.StickerPack),
+		packStickers: make(map[uuid.UUID]map[uuid.UUID]*models.PackSticker),
 	}
 }
 
@@ -88,6 +92,131 @@ func (m *mockStickerRepo) Search(ctx context.Context, query string, serverID *uu
 		// Simple name search
 		if s.Name == query {
 			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+// Sticker Pack methods
+func (m *mockStickerRepo) CreatePack(ctx context.Context, pack *models.StickerPack) error {
+	m.packs[pack.ID] = pack
+	m.packStickers[pack.ID] = make(map[uuid.UUID]*models.PackSticker)
+	return nil
+}
+
+func (m *mockStickerRepo) GetPackByID(ctx context.Context, id uuid.UUID) (*models.StickerPack, error) {
+	pack, ok := m.packs[id]
+	if !ok {
+		return nil, nil
+	}
+	return pack, nil
+}
+
+func (m *mockStickerRepo) UpdatePack(ctx context.Context, pack *models.StickerPack) error {
+	m.packs[pack.ID] = pack
+	return nil
+}
+
+func (m *mockStickerRepo) DeletePack(ctx context.Context, id uuid.UUID) error {
+	delete(m.packs, id)
+	delete(m.packStickers, id)
+	return nil
+}
+
+func (m *mockStickerRepo) GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.ServerID != nil && *p.ServerID == serverID {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetGlobalPacks(ctx context.Context) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.IsGlobal {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetPacksByTier(ctx context.Context, tier models.StickerPackTier) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for _, p := range m.packs {
+		if p.Tier == tier {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetAvailablePacks(ctx context.Context, serverID *uuid.UUID, userTier models.StickerPackTier) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	tierOrder := map[models.StickerPackTier]int{
+		models.StickerPackTierFree:    0,
+		models.StickerPackTierBasic:   1,
+		models.StickerPackTierPremium: 2,
+	}
+	userLevel := tierOrder[userTier]
+
+	for _, p := range m.packs {
+		if !p.IsActive {
+			continue
+		}
+		if p.IsGlobal || (serverID != nil && p.ServerID != nil && *p.ServerID == *serverID) {
+			if tierOrder[p.Tier] <= userLevel {
+				result = append(result, p)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) AddStickerToPack(ctx context.Context, packID, stickerID uuid.UUID, position int, isDefault bool) error {
+	if _, ok := m.packStickers[packID]; !ok {
+		m.packStickers[packID] = make(map[uuid.UUID]*models.PackSticker)
+	}
+	m.packStickers[packID][stickerID] = &models.PackSticker{
+		ID:        uuid.New(),
+		PackID:    packID,
+		StickerID: stickerID,
+		Position:  position,
+		IsDefault: isDefault,
+	}
+	return nil
+}
+
+func (m *mockStickerRepo) RemoveStickerFromPack(ctx context.Context, packID, stickerID uuid.UUID) error {
+	if pack, ok := m.packStickers[packID]; ok {
+		delete(pack, stickerID)
+	}
+	return nil
+}
+
+func (m *mockStickerRepo) GetStickersInPack(ctx context.Context, packID uuid.UUID) ([]*models.Sticker, error) {
+	stickerIDs, ok := m.packStickers[packID]
+	if !ok {
+		return nil, nil
+	}
+	var result []*models.Sticker
+	for stickerID := range stickerIDs {
+		if sticker, ok := m.stickers[stickerID]; ok {
+			result = append(result, sticker)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStickerRepo) GetPacksContainingSticker(ctx context.Context, stickerID uuid.UUID) ([]*models.StickerPack, error) {
+	var result []*models.StickerPack
+	for packID, stickers := range m.packStickers {
+		if _, ok := stickers[stickerID]; ok {
+			if pack, ok := m.packs[packID]; ok {
+				result = append(result, pack)
+			}
 		}
 	}
 	return result, nil
@@ -260,11 +389,12 @@ func TestStickerService_Get(t *testing.T) {
 
 	ctx := context.Background()
 	sticker := &models.Sticker{
-		ID:     uuid.New(),
-		Name:   "TestSticker",
-		Tags:   []string{"test"},
-		URL:    "/stickers/test.png",
-		Format: models.StickerFormatPNG,
+		ID:           uuid.New(),
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -295,13 +425,14 @@ func TestStickerService_GetByServer(t *testing.T) {
 	serverID := uuid.New()
 
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  &serverID,
-		Name:      "TestSticker",
-		Tags:      []string{"test"},
-		URL:       "/stickers/test.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -320,26 +451,28 @@ func TestStickerService_GetGlobal(t *testing.T) {
 
 	// Add global sticker
 	globalSticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  nil,
-		Name:      "GlobalSticker",
-		Tags:      []string{"global"},
-		URL:       "/stickers/global.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     nil,
+		Name:         "GlobalSticker",
+		Tags:         []string{"global"},
+		URL:          "/stickers/global.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, globalSticker)
 
 	// Add server-specific sticker
 	serverID := uuid.New()
 	serverSticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  &serverID,
-		Name:      "ServerSticker",
-		Tags:      []string{"server"},
-		URL:       "/stickers/server.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "ServerSticker",
+		Tags:         []string{"server"},
+		URL:          "/stickers/server.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, serverSticker)
 
@@ -359,29 +492,31 @@ func TestStickerService_GetAvailable(t *testing.T) {
 
 	// Add global sticker
 	globalSticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  nil,
-		Name:      "GlobalSticker",
-		Tags:      []string{"global"},
-		URL:       "/stickers/global.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     nil,
+		Name:         "GlobalSticker",
+		Tags:         []string{"global"},
+		URL:          "/stickers/global.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, globalSticker)
 
 	// Add server-specific sticker
 	serverSticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  &serverID,
-		Name:      "ServerSticker",
-		Tags:      []string{"server"},
-		URL:       "/stickers/server.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "ServerSticker",
+		Tags:         []string{"server"},
+		URL:          "/stickers/server.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, serverSticker)
 
-	stickers, err := service.GetAvailable(ctx, &serverID)
+	stickers, err := service.GetAvailable(ctx, &serverID, models.StickerPackTierFree)
 
 	assert.NoError(t, err)
 	assert.Len(t, stickers, 2)
@@ -393,12 +528,13 @@ func TestStickerService_Update(t *testing.T) {
 
 	ctx := context.Background()
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		Name:      "OldName",
-		Tags:      []string{"old"},
-		URL:       "/stickers/test.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		Name:         "OldName",
+		Tags:         []string{"old"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -427,12 +563,13 @@ func TestStickerService_Update_NameTooLong(t *testing.T) {
 
 	ctx := context.Background()
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		Name:      "OldName",
-		Tags:      []string{"old"},
-		URL:       "/stickers/test.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		Name:         "OldName",
+		Tags:         []string{"old"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -453,12 +590,13 @@ func TestStickerService_Delete(t *testing.T) {
 
 	ctx := context.Background()
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		Name:      "TestSticker",
-		Tags:      []string{"test"},
-		URL:       "/stickers/test.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -489,13 +627,14 @@ func TestStickerService_Search(t *testing.T) {
 	serverID := uuid.New()
 
 	sticker := &models.Sticker{
-		ID:        uuid.New(),
-		ServerID:  &serverID,
-		Name:      "TestSticker",
-		Tags:      []string{"test"},
-		URL:       "/stickers/test.png",
-		Format:    models.StickerFormatPNG,
-		CreatedBy: uuid.New(),
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    uuid.New(),
 	}
 	mockRepo.Create(ctx, sticker)
 
@@ -504,4 +643,196 @@ func TestStickerService_Search(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, sticker.ID, results[0].ID)
+}
+
+// Sticker Pack Tests
+
+func TestStickerService_CreatePack(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	desc := "Test pack description"
+
+	pack, err := service.CreatePack(ctx, "Test Pack", &desc, nil, models.StickerPackTierFree, false, nil, userID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, pack)
+	assert.Equal(t, "Test Pack", pack.Name)
+	assert.Equal(t, models.StickerPackTierFree, pack.Tier)
+	assert.True(t, pack.IsActive)
+}
+
+func TestStickerService_CreatePack_NoName(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	pack, err := service.CreatePack(ctx, "", nil, nil, models.StickerPackTierFree, false, nil, userID)
+
+	assert.ErrorIs(t, err, ErrPackNameRequired)
+	assert.Nil(t, pack)
+}
+
+func TestStickerService_CreatePack_NameTooLong(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	longName := ""
+	for i := 0; i < 105; i++ {
+		longName += "a"
+	}
+
+	pack, err := service.CreatePack(ctx, longName, nil, nil, models.StickerPackTierFree, false, nil, userID)
+
+	assert.ErrorIs(t, err, ErrPackNameTooLong)
+	assert.Nil(t, pack)
+}
+
+func TestStickerService_GetPack(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	// Create a pack first
+	createdPack, _ := service.CreatePack(ctx, "Test Pack", nil, nil, models.StickerPackTierFree, false, nil, userID)
+
+	// Retrieve it
+	retrieved, err := service.GetPack(ctx, createdPack.ID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, createdPack.ID, retrieved.ID)
+	assert.Equal(t, "Test Pack", retrieved.Name)
+}
+
+func TestStickerService_GetPack_NotFound(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+
+	retrieved, err := service.GetPack(ctx, uuid.New())
+
+	assert.ErrorIs(t, err, ErrPackNotFound)
+	assert.Nil(t, retrieved)
+}
+
+func TestStickerService_GetPackWithStickers(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	serverID := uuid.New()
+
+	// Create a sticker
+	sticker := &models.Sticker{
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    userID,
+	}
+	mockRepo.Create(ctx, sticker)
+
+	// Create a pack
+	pack, _ := service.CreatePack(ctx, "Test Pack", nil, nil, models.StickerPackTierFree, false, &serverID, userID)
+
+	// Add sticker to pack
+	err := service.AddStickerToPack(ctx, pack.ID, sticker.ID, 0, false)
+	assert.NoError(t, err)
+
+	// Get pack with stickers
+	retrieved, err := service.GetPackWithStickers(ctx, pack.ID, models.StickerPackTierFree)
+
+	assert.NoError(t, err)
+	assert.Equal(t, pack.ID, retrieved.ID)
+	assert.Len(t, retrieved.Stickers, 1)
+	assert.Equal(t, sticker.ID, retrieved.Stickers[0].ID)
+}
+
+func TestStickerService_DeletePack(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	// Create a pack
+	pack, _ := service.CreatePack(ctx, "Test Pack", nil, nil, models.StickerPackTierFree, false, nil, userID)
+
+	// Delete it
+	err := service.DeletePack(ctx, pack.ID)
+	assert.NoError(t, err)
+
+	// Try to retrieve it
+	retrieved, err := service.GetPack(ctx, pack.ID)
+	assert.ErrorIs(t, err, ErrPackNotFound)
+	assert.Nil(t, retrieved)
+}
+
+func TestStickerService_AddStickerToPack(t *testing.T) {
+	mockRepo := newMockStickerRepo()
+	service := NewStickerService(mockRepo, nil)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	serverID := uuid.New()
+
+	// Create a sticker
+	sticker := &models.Sticker{
+		ID:           uuid.New(),
+		ServerID:     &serverID,
+		Name:         "TestSticker",
+		Tags:         []string{"test"},
+		URL:          "/stickers/test.png",
+		Format:       models.StickerFormatPNG,
+		RequiredTier: models.StickerPackTierFree,
+		CreatedBy:    userID,
+	}
+	mockRepo.Create(ctx, sticker)
+
+	// Create a pack
+	pack, _ := service.CreatePack(ctx, "Test Pack", nil, nil, models.StickerPackTierFree, false, &serverID, userID)
+
+	// Add sticker to pack
+	err := service.AddStickerToPack(ctx, pack.ID, sticker.ID, 0, true)
+	assert.NoError(t, err)
+}
+
+func TestTierMeetsRequirement(t *testing.T) {
+	testCases := []struct {
+		name         string
+		userTier     models.StickerPackTier
+		requiredTier models.StickerPackTier
+		expected     bool
+	}{
+		{"free user can access free", models.StickerPackTierFree, models.StickerPackTierFree, true},
+		{"free user cannot access basic", models.StickerPackTierFree, models.StickerPackTierBasic, false},
+		{"free user cannot access premium", models.StickerPackTierFree, models.StickerPackTierPremium, false},
+		{"basic user can access free", models.StickerPackTierBasic, models.StickerPackTierFree, true},
+		{"basic user can access basic", models.StickerPackTierBasic, models.StickerPackTierBasic, true},
+		{"basic user cannot access premium", models.StickerPackTierBasic, models.StickerPackTierPremium, false},
+		{"premium user can access free", models.StickerPackTierPremium, models.StickerPackTierFree, true},
+		{"premium user can access basic", models.StickerPackTierPremium, models.StickerPackTierBasic, true},
+		{"premium user can access premium", models.StickerPackTierPremium, models.StickerPackTierPremium, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := models.TierMeetsRequirement(tc.userTier, tc.requiredTier)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Implements the **Advanced Sticker System** P0 feature with:

### Features Implemented

1. **Premium Sticker Packs** - Sticker pack system with tiers (Free, Basic, Premium) that map to subscription tiers
2. **Server Stickers** - Server admins can create custom sticker packs for their servers  
3. **Animated Stickers** - Full support for APNG and GIF sticker formats (already in model, now integrated in service/handler)
4. **Monetization Integration** - Sticker packs linked to subscription tiers (Basic .99, Premium .99)

### Database Changes
- New migration :
  -  table with tier, global/server scope
  -  join table for many-to-many relationship
  -  column on stickers for premium sticker gating
  - Auto-updating sticker_count on packs via trigger

### API Changes
- New endpoints:
  -  - List global sticker packs
  -  - Get pack with stickers
  -  - List server packs
  -  - Create pack
  -  - Update pack
  -  - Delete pack
  -  - Add sticker to pack
  -  - Remove sticker from pack

### Subscription Tier Access
- **Free tier**: Access to free stickers and packs only
- **Basic tier** (.99): Access to basic and free content
- **Premium tier** (.99): Full access to all content

### Tests
- Updated sticker service tests with new pack operations
- Updated sticker handler tests
- All tests passing

Closes P0 feature request