### PR TITLE
test(handler): add mock-based tests for AI chat template listing

### DIFF
--- a/backend/internal/api/handlers/ai_chat.go
+++ b/backend/internal/api/handlers/ai_chat.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -14,13 +15,35 @@ import (
 	"hearth/internal/models"
 )
 
+// ChatServiceInterface defines the interface for AI chat service operations.
+// This enables dependency injection and mock testing.
+type ChatServiceInterface interface {
+	CreateConversation(ctx context.Context, userID uuid.UUID, req *models.CreateConversationRequest) (*models.AIConversation, error)
+	GetConversationWithMessages(ctx context.Context, userID, conversationID uuid.UUID, limit int) (*models.AIConversationWithMessages, error)
+	ListConversations(ctx context.Context, params *models.ConversationListParams) ([]*models.AIConversation, error)
+	UpdateConversation(ctx context.Context, userID, conversationID uuid.UUID, req *models.UpdateConversationRequest) (*models.AIConversation, error)
+	DeleteConversation(ctx context.Context, userID, conversationID uuid.UUID) error
+	SendMessage(ctx context.Context, userID, conversationID uuid.UUID, req *models.SendChatMessageRequest) (*models.ConversationMessage, error)
+	SendMessageStream(ctx context.Context, userID, conversationID uuid.UUID, req *models.SendChatMessageRequest, callback func(*models.StreamChunk) error) (*models.ConversationMessage, error)
+	RegenerateMessage(ctx context.Context, userID, conversationID, messageID uuid.UUID, stream bool, callback func(*models.StreamChunk) error) (*models.ConversationMessage, error)
+	GetConversationMessages(ctx context.Context, userID, conversationID uuid.UUID, limit, offset int) ([]*models.ConversationMessage, error)
+	DeleteMessage(ctx context.Context, userID, conversationID, messageID uuid.UUID) error
+	GetTemplates(ctx context.Context, userID *uuid.UUID, category string) ([]*models.AIChatTemplate, error)
+	GetTemplate(ctx context.Context, id uuid.UUID) (*models.AIChatTemplate, error)
+	CreateTemplate(ctx context.Context, userID uuid.UUID, tmpl *models.AIChatTemplate) error
+	UpdateTemplate(ctx context.Context, userID uuid.UUID, tmpl *models.AIChatTemplate) error
+	DeleteTemplate(ctx context.Context, userID, templateID uuid.UUID) error
+	ShareConversation(ctx context.Context, userID, conversationID uuid.UUID, isPublic, canContinue bool, expiresIn *time.Duration) (*models.AIConversationShare, error)
+	GetSharedConversation(ctx context.Context, shareCode string) (*models.AIConversationWithMessages, error)
+}
+
 // AIChatHandler handles AI chat endpoints
 type AIChatHandler struct {
-	chatService *ai.ChatService
+	chatService ChatServiceInterface
 }
 
 // NewAIChatHandler creates a new AIChatHandler
-func NewAIChatHandler(chatService *ai.ChatService) *AIChatHandler {
+func NewAIChatHandler(chatService ChatServiceInterface) *AIChatHandler {
 	return &AIChatHandler{chatService: chatService}
 }
 

--- a/backend/internal/api/handlers/ai_chat_test.go
+++ b/backend/internal/api/handlers/ai_chat_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -200,11 +202,9 @@ func setupAIChatTestApp(t testing.TB, handler *AIChatHandler) *fiber.App {
 // Tests for Conversations
 
 func TestListConversations(t *testing.T) {
-	_ = new(MockChatService) // TODO: use mock service when handler supports injection
+	// Use real ChatService for tests that don't need mock verification;
+	// use MockChatService for tests that verify specific service calls.
 	handler := NewAIChatHandler(&ai.ChatService{})
-	// We need to use reflection or expose the service - for now, test the interface
-
-	_ = uuid.New() // TODO: use for authenticated tests
 
 	t.Run("unauthorized without user ID", func(t *testing.T) {
 		app := setupAIChatTestApp(t, handler)
@@ -499,11 +499,82 @@ func TestDeleteMessage(t *testing.T) {
 
 func TestListTemplates(t *testing.T) {
 	t.Run("templates accessible without auth for public", func(t *testing.T) {
-		t.Skip("TODO: requires mock service with initialized dependencies")
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+
+		publicTemplates := []*models.AIChatTemplate{
+			{
+				ID:          uuid.New(),
+				Name:        "Public Assistant",
+				SystemPrompt: "You are a helpful assistant",
+				Category:    stringPtr("general"),
+				IsPublic:    true,
+			},
+		}
+		mockSvc.On("GetTemplates", mock.Anything, (*uuid.UUID)(nil), "").Return(publicTemplates, nil)
+
+		app := setupAIChatTestApp(t, handler)
+		req := httptest.NewRequest("GET", "/api/v1/ai/templates", nil)
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		body, _ := io.ReadAll(resp.Body)
+		var result map[string][]*models.AIChatTemplate
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Len(t, result["templates"], 1)
+		assert.Equal(t, "Public Assistant", result["templates"][0].Name)
+		mockSvc.AssertExpectations(t)
 	})
 
 	t.Run("templates with category filter", func(t *testing.T) {
-		t.Skip("TODO: requires mock service with initialized dependencies")
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+
+		userID := uuid.New()
+		filteredTemplates := []*models.AIChatTemplate{
+			{
+				ID:           uuid.New(),
+				Name:         "Coding Assistant",
+				SystemPrompt: "You are a coding expert",
+				Category:     stringPtr("programming"),
+				IsPublic:     true,
+			},
+		}
+		mockSvc.On("GetTemplates", mock.Anything, &userID, "programming").Return(filteredTemplates, nil)
+
+		app := setupAIChatTestApp(t, handler)
+		req := httptest.NewRequest("GET", "/api/v1/ai/templates?category=programming", nil)
+		req.Header.Set("X-Test-User-ID", userID.String())
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		body, _ := io.ReadAll(resp.Body)
+		var result map[string][]*models.AIChatTemplate
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Len(t, result["templates"], 1)
+		assert.Equal(t, "Coding Assistant", result["templates"][0].Name)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("templates returns internal error on service failure", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+
+		mockSvc.On("GetTemplates", mock.Anything, (*uuid.UUID)(nil), "").Return(nil, errors.New("database error"))
+
+		app := setupAIChatTestApp(t, handler)
+		req := httptest.NewRequest("GET", "/api/v1/ai/templates", nil)
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+		mockSvc.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
- Introduce ChatServiceInterface to enable dependency injection in AIChatHandler
- Replace concrete *ai.ChatService with ChatServiceInterface interface type
- Enable MockChatService usage for tests, removing 2 skipped test cases
- Add 3 TestListTemplates sub-tests: public listing, category filter, error handling
- Clean up stale TODO comments from TestListConversations
