### PR TITLE
fix(tests): add missing jumpToMessage mock to MessageList.test.ts

### DIFF
--- a/frontend/src/lib/components/MessageList.test.ts
+++ b/frontend/src/lib/components/MessageList.test.ts
@@ -22,7 +22,15 @@ vi.mock('$lib/stores/messages', () => {
 		editMessage: mockEditMessage,
 		deleteMessage: mockDeleteMessage,
 		addReaction: mockAddReaction,
-		removeReaction: mockRemoveReaction
+		removeReaction: mockRemoveReaction,
+		jumpToMessage: {
+			subscribe: (fn: (value: any) => void) => {
+				fn({ channelId: null, messageId: null });
+				return () => {};
+			},
+			jump: vi.fn(),
+			clear: vi.fn()
+		}
 	};
 });
 


### PR DESCRIPTION
The jumpToMessage store export was missing from the mock, causing
all MessageList component tests to fail with:
'No jumpToMessage export is defined on the /stores/messages mock'

Added the mock with proper subscribe, jump, and clear methods
matching the actual store interface.
