### PR TITLE
fix(tests): use regular function constructor for WebSocket mock

### DIFF
--- a/PRDs/2026-04-03_advanced-voice-experience.md
+++ b/PRDs/2026-04-03_advanced-voice-experience.md
@@ -1,0 +1,146 @@
+---
+feature: Advanced Voice Experience & Audio Intelligence
+discord_equivalent: Voice Settings → Advanced (noise suppression, echo cancellation, auto gain control)
+priority: P0
+complexity: High
+estimated_effort: 10-12 weeks
+---
+
+# Advanced Voice Experience & Audio Intelligence
+
+## Overview
+
+Discord's voice quality superiority comes from advanced audio processing: noise suppression, echo cancellation, automatic gain control, and voice activity detection. Users consistently rate voice quality as Discord's biggest competitive advantage. Without these features, Hearth's voice experience feels amateur compared to Discord, Zoom, or modern voice platforms.
+
+## Discord Feature Parity
+
+### Core Audio Processing
+- **Noise Suppression**: Krisp-powered AI noise cancellation (keyboard typing, background noise, pets)
+- **Echo Cancellation**: Acoustic echo cancellation to prevent feedback loops
+- **Automatic Gain Control**: Normalizes microphone volume across participants
+- **Voice Activity Detection**: Smart detection vs push-to-talk with customizable sensitivity
+
+### Advanced Features
+- **Noise Gate**: Configurable threshold to filter low-level noise
+- **Audio Quality Indicators**: Real-time connection quality display
+- **Bandwidth Optimization**: Dynamic quality adjustment based on connection
+- **Platform Audio Integration**: System audio routing and capture
+
+## User Value Proposition
+
+- **Professional Voice Quality**: Compete with Zoom/Teams for business adoption
+- **Accessibility**: Users with poor microphones or noisy environments can participate
+- **Engagement**: Higher voice channel participation when audio quality is excellent
+- **Competitive Gaming**: Critical for esports and competitive gaming communities
+- **Content Creation**: Streamers and content creators need professional audio
+
+## Technical Implementation
+
+### Client-Side Audio Processing (WebRTC)
+```typescript
+// Enhanced audio constraints with processing
+interface AdvancedAudioConstraints {
+  echoCancellation: boolean;
+  noiseSuppression: boolean;
+  autoGainControl: boolean;
+  voiceActivityDetection: boolean;
+  channelCount: number;
+  sampleRate: number; // 16kHz, 48kHz options
+}
+
+// Real-time audio quality metrics
+interface AudioQualityMetrics {
+  signalLevel: number; // dB level
+  noiseLevel: number;
+  echoCancellationQuality: number;
+  networkQuality: 'excellent' | 'good' | 'poor';
+  bitrate: number;
+  packetLoss: number;
+}
+```
+
+### Server-Side Audio Processing
+```go
+// Audio processing pipeline
+type AudioProcessor struct {
+    NoiseGate      *NoiseGate
+    EchoCancel     *EchoCanceller
+    GainControl    *AutoGainControl
+    QualityMonitor *QualityMonitor
+    Compressor     *AudioCompressor
+}
+
+// Real-time audio quality monitoring
+type VoiceQuality struct {
+    UserID        uuid.UUID
+    ChannelID     uuid.UUID
+    SignalStrength float64  // -100 to 0 dB
+    NoiseLevel     float64  // Background noise estimate
+    EchoDetected   bool
+    BitRate        int      // Current encoding bitrate
+    PacketLoss     float64  // 0-100%
+    Latency        int      // RTT in milliseconds
+}
+```
+
+### Audio Settings Per-User
+```go
+type AudioSettings struct {
+    UserID                uuid.UUID
+    NoiseSuppressionLevel string   // off, low, medium, high
+    EchoCancellation     bool
+    AutoGainControl      bool
+    VoiceActivitySensitivity float64 // 0.0-1.0
+    NoiseGateThreshold   float64   // dB threshold
+    InputVolume          float64   // 0.0-2.0 multiplier
+    OutputVolume         float64   // 0.0-2.0 multiplier
+    PushToTalkEnabled    bool
+    PushToTalkKey        string
+}
+```
+
+### Performance Monitoring
+- **Audio Quality Dashboard**: Real-time quality metrics for voice channels
+- **Connection Diagnostics**: Latency, packet loss, bitrate monitoring
+- **User Experience Metrics**: Audio drop rates, reconnection frequency
+- **A/B Testing Framework**: Compare audio processing effectiveness
+
+## Dependencies
+
+- **WebRTC Enhancement**: Advanced audio constraints and processing
+- **Audio Processing Libraries**:
+  - Web: AudioWorklet API, TensorFlow.js for noise suppression
+  - Desktop: FMOD/OpenAL with audio processing plugins
+  - Mobile: Platform-specific audio processing (iOS: Audio Unit, Android: AAudio)
+- **Backend Audio Analysis**: Real-time quality monitoring and analytics
+- **Settings Infrastructure**: Per-user audio preferences storage
+
+## Success Metrics
+
+- **Voice Usage Increase**: 40% increase in voice channel hours after deployment
+- **Audio Quality Scores**: User-reported quality rating >4.5/5.0 (vs current baseline)
+- **Enterprise Adoption**: 60% of business-focused servers adopt voice features
+- **Competitive Positioning**: Voice quality rated equal to or better than Discord in user surveys
+- **Technical Metrics**: <5% audio-related support tickets, <2% call drop rate
+
+## Implementation Phases
+
+### Phase 1 (4 weeks): Core Audio Processing
+- Browser-based noise suppression (AudioWorklet + TensorFlow.js)
+- Echo cancellation via WebRTC constraints
+- Basic automatic gain control
+- Audio quality indicator UI
+
+### Phase 2 (4 weeks): Advanced Processing & Settings
+- Configurable noise suppression levels (off/low/medium/high)
+- Voice activity detection with sensitivity control
+- Noise gate with threshold adjustment
+- Comprehensive audio settings panel
+
+### Phase 3 (4 weeks): Quality Monitoring & Analytics
+- Real-time connection quality display
+- Audio analytics dashboard for server admins
+- Bandwidth optimization and quality adaptation
+- Performance monitoring and alerting
+
+This feature directly addresses user complaints about "poor voice quality compared to Discord" and positions Hearth as a professional-grade platform suitable for business use, content creation, and competitive gaming.

--- a/PRDs/2026-04-03_comprehensive-audit-logs.md
+++ b/PRDs/2026-04-03_comprehensive-audit-logs.md
@@ -1,0 +1,103 @@
+---
+feature: Comprehensive Audit Logs & Moderation Analytics
+discord_equivalent: Server Settings → Audit Log (complete parity)
+priority: P0
+complexity: High
+estimated_effort: 8-10 weeks
+---
+
+# Comprehensive Audit Logs & Moderation Analytics
+
+## Overview
+
+Discord's audit log is the backbone of server moderation and community management. Without comprehensive audit logs, large communities cannot effectively track moderation actions, detect abuse patterns, or maintain accountability. This is a **critical enterprise and large community adoption blocker**.
+
+## Discord Feature Parity
+
+Discord's audit log tracks 80+ event types including:
+- **Member Actions**: joins, leaves, kicks, bans, unbans, timeouts, role changes, nickname changes
+- **Channel Management**: create, update, delete, permission overwrites
+- **Server Configuration**: settings changes, role management, emoji management
+- **Message Moderation**: bulk deletes, pins, thread operations
+- **Integration Management**: webhook changes, bot permissions, slash commands
+
+## User Value Proposition
+
+- **Community Trust**: Transparent moderation builds user confidence
+- **Enterprise Adoption**: Organizations require audit trails for compliance
+- **Moderation Efficiency**: Quick identification of problem patterns and bad actors
+- **Admin Accountability**: Tracks who performed what actions when
+- **Incident Response**: Critical for investigating harassment, raids, or security breaches
+
+## Technical Implementation
+
+### Database Schema
+```sql
+-- Audit log entries with event metadata
+CREATE TABLE audit_log_entries (
+    id UUID PRIMARY KEY,
+    server_id UUID NOT NULL,
+    user_id UUID, -- Who performed the action
+    target_id UUID, -- What was affected
+    action_type TEXT NOT NULL, -- MEMBER_KICK, CHANNEL_DELETE, etc.
+    reason TEXT,
+    changes JSONB, -- Before/after values
+    metadata JSONB, -- Additional context
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Efficient querying indexes
+CREATE INDEX audit_log_server_time ON audit_log_entries (server_id, created_at DESC);
+CREATE INDEX audit_log_action_type ON audit_log_entries (action_type);
+CREATE INDEX audit_log_user ON audit_log_entries (user_id);
+```
+
+### Event Types (80+ like Discord)
+- **10-19**: Member events (join, leave, kick, ban, timeout, role update)
+- **20-29**: Channel events (create, update, delete, permission overwrite)
+- **30-39**: Server events (settings, roles, emoji, integration)
+- **40-49**: Message events (delete, bulk delete, pin, thread)
+- **50-59**: Permission events (role create/update/delete, overwrites)
+- **60-69**: Integration events (webhook, bot, slash command)
+- **70-79**: Voice/stage events (voice state, stage management)
+- **80-89**: Auto-moderation events (rule trigger, action taken)
+
+### Analytics Dashboard
+- **Moderation Activity**: Actions per day/week/month charts
+- **Top Moderators**: Most active staff members
+- **Event Distribution**: Pie charts of action types
+- **Member Trends**: Join/leave rates, kick/ban patterns
+- **Auto-mod Effectiveness**: Trigger rates and false positives
+- **Search & Filtering**: By user, action type, date range, reason keywords
+
+## Dependencies
+
+- **Permissions System**: Audit log view permission (already exists)
+- **Event Bus**: Instrumentation hooks in all moderation actions
+- **Analytics Infrastructure**: Charts and reporting framework
+
+## Success Metrics
+
+- **Enterprise Adoption**: 50% of large servers (>1000 members) use audit logs weekly
+- **Moderation Efficiency**: 30% reduction in investigation time for incidents
+- **Community Trust**: Reduced complaints about "unfair" moderation via transparency
+- **Feature Stickiness**: 90% of servers with audit log access continue using it monthly
+
+## Implementation Phases
+
+### Phase 1 (4 weeks): Core Audit Log
+- Event capture for 20 most critical actions
+- Basic audit log viewing with pagination
+- Search by action type and user
+
+### Phase 2 (3 weeks): Complete Event Coverage
+- All 80+ Discord-parity event types
+- Advanced search with date ranges and reason keywords
+- Reason tracking for all moderation actions
+
+### Phase 3 (3 weeks): Analytics & Dashboard
+- Moderation analytics dashboard
+- Export functionality (CSV, JSON)
+- Advanced filtering and visualization
+
+This feature directly addresses the #1 blocker for enterprise/organization adoption and positions Hearth as a serious Discord alternative for communities requiring governance and accountability.

--- a/PRDs/2026-04-03_native-mobile-push-system.md
+++ b/PRDs/2026-04-03_native-mobile-push-system.md
@@ -1,0 +1,202 @@
+---
+feature: Native Mobile Push Notification System
+discord_equivalent: Mobile App → Notifications (complete iOS/Android native push)
+priority: P0
+complexity: High
+estimated_effort: 6-8 weeks
+---
+
+# Native Mobile Push Notification System
+
+## Overview
+
+Mobile push notifications are the #1 driver of user engagement and retention for social platforms. Discord's mobile engagement dominates because of intelligent, timely push notifications. Without native mobile push, Hearth cannot compete for mobile-first users or achieve sustainable daily/weekly active user growth. This is a **critical user retention and growth blocker**.
+
+## Discord Feature Parity
+
+### Push Notification Types
+- **Direct Messages**: Immediate push for all DMs with sender name/message preview
+- **Mentions**: @username mentions in channels with channel/server context
+- **Replies**: Thread replies and message replies with context
+- **Server Events**: Friend requests, server invites, role pings
+- **Live Events**: Go Live notifications, stage channel announcements
+- **Custom Keywords**: User-defined keyword alerts across servers
+
+### Smart Delivery Features
+- **Intelligent Batching**: Group related notifications to reduce spam
+- **Priority Scoring**: VIP users, important servers, urgent keywords get immediate delivery
+- **Quiet Hours**: User-configurable do not disturb times
+- **Granular Control**: Per-server, per-channel notification settings
+- **Platform Sync**: Dismiss on one device removes from all devices
+
+## User Value Proposition
+
+- **User Retention**: 3x higher 7-day retention with push notifications enabled
+- **Engagement**: 40% higher daily active usage with smart notifications
+- **Mobile-First Users**: Critical for younger demographics who expect instant mobile responses
+- **Community Building**: Real-time notifications drive conversation momentum
+- **Business Communication**: Professional teams need reliable mobile alerts
+
+## Technical Implementation
+
+### Mobile Platform Integration
+```typescript
+// iOS (Swift/React Native)
+import UserNotifications
+
+class HearthNotificationService: UNNotificationServiceExtension {
+    func didReceive(request: UNNotificationRequest,
+                   withContentHandler: (UNNotificationContent) -> Void) {
+        // Rich notification processing
+        let content = request.content.mutableCopy()
+        content.title = enrichTitle(from: request.userInfo)
+        content.body = enrichBody(from: request.userInfo)
+        content.sound = customSound(for: request.userInfo["type"])
+        withContentHandler(content)
+    }
+}
+
+// Android (Kotlin/React Native)
+class HearthFirebaseService : FirebaseMessagingService() {
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        val notification = buildRichNotification(remoteMessage.data)
+        NotificationManagerCompat.from(this).notify(
+            generateNotificationId(),
+            notification
+        )
+    }
+}
+```
+
+### Backend Push Infrastructure
+```go
+// Push notification delivery system
+type PushDeliveryService struct {
+    APNSClient     *apns.Client      // iOS delivery
+    FCMClient      *fcm.Client       // Android delivery
+    WebPushClient  *webpush.Client   // Browser delivery
+    Templates      *TemplateEngine   // Notification templates
+    Analytics      *AnalyticsTracker // Delivery tracking
+}
+
+type PushNotification struct {
+    UserID          uuid.UUID            `json:"user_id"`
+    Type            NotificationType     `json:"type"`
+    Priority        Priority             `json:"priority"`
+    Title           string               `json:"title"`
+    Body            string               `json:"body"`
+    Sound           string               `json:"sound,omitempty"`
+    Badge           int                  `json:"badge,omitempty"`
+    Data            map[string]string    `json:"data"`
+    ScheduledFor    *time.Time           `json:"scheduled_for,omitempty"`
+    ExpiresAt       time.Time            `json:"expires_at"`
+    Platforms       []Platform           `json:"platforms"` // iOS, Android, Web
+}
+
+// Smart delivery logic
+type DeliveryStrategy struct {
+    ImmediateTypes  []NotificationType // DMs, mentions - always immediate
+    BatchedTypes    []NotificationType // Reactions, server events - can batch
+    QuietHours      QuietHoursConfig   // Per-user do not disturb
+    FrequencyCap    FrequencyConfig    // Max notifications per hour/day
+    UserPreferences UserNotificationSettings
+}
+```
+
+### Intelligent Notification Scoring
+```go
+type NotificationScorer struct {
+    RelationshipWeight map[RelationshipType]float64 // Friend=1.0, Server member=0.3
+    ChannelImportance  map[uuid.UUID]float64        // Per-channel user importance
+    KeywordMatches     []string                      // User-defined keywords
+    TimeDecayFactor    float64                       // Recent activity boost
+    EngagementHistory  UserEngagementProfile         // Historical interaction patterns
+}
+
+func (s *NotificationScorer) CalculatePriority(notification *PushNotification, user *User) Priority {
+    score := 0.0
+
+    // Relationship scoring
+    score += s.RelationshipWeight[notification.SenderRelationship] * 0.4
+
+    // Channel importance
+    score += s.ChannelImportance[notification.ChannelID] * 0.3
+
+    // Keyword matching
+    if s.MatchesKeywords(notification.Content) {
+        score += 0.8
+    }
+
+    // Time-based relevance
+    score *= s.TimeDecayFactor
+
+    // Convert score to priority
+    switch {
+    case score >= 0.8: return PriorityUrgent
+    case score >= 0.6: return PriorityHigh
+    case score >= 0.4: return PriorityNormal
+    default: return PriorityLow
+    }
+}
+```
+
+### User Notification Preferences
+```go
+type UserNotificationSettings struct {
+    UserID            uuid.UUID                 `json:"user_id"`
+    GlobalEnabled     bool                      `json:"global_enabled"`
+    QuietHours        QuietHoursConfig          `json:"quiet_hours"`
+    MaxPerHour        int                       `json:"max_per_hour"`
+    Keywords          []string                  `json:"keywords"`
+    ServerSettings    map[uuid.UUID]ServerPushSettings `json:"server_settings"`
+    ChannelSettings   map[uuid.UUID]ChannelPushSettings `json:"channel_settings"`
+    TypeSettings      map[NotificationType]bool `json:"type_settings"`
+}
+
+type QuietHoursConfig struct {
+    Enabled     bool      `json:"enabled"`
+    StartTime   TimeOfDay `json:"start_time"`   // 22:00
+    EndTime     TimeOfDay `json:"end_time"`     // 08:00
+    Timezone    string    `json:"timezone"`
+    AllowUrgent bool      `json:"allow_urgent"` // Emergency overrides
+}
+```
+
+## Dependencies
+
+- **Mobile App Infrastructure**: iOS and Android native app development
+- **Push Provider Setup**: APNs (iOS), FCM (Android), Web Push API
+- **Certificate Management**: Apple Developer certificates, FCM service keys
+- **Analytics Platform**: Delivery tracking, open rates, engagement metrics
+- **Template System**: Rich notification content generation
+
+## Success Metrics
+
+- **Push Opt-in Rate**: >70% of mobile users enable push notifications
+- **Engagement Lift**: 40% increase in DAU with push notifications enabled
+- **Delivery Success**: >95% successful push delivery rate
+- **Response Rate**: >25% notification click-through rate
+- **Retention Impact**: 50% improvement in 7-day retention for push-enabled users
+- **Complaint Rate**: <1% users disable notifications due to spam
+
+## Implementation Phases
+
+### Phase 1 (3 weeks): Core Push Infrastructure
+- APNs and FCM client integration
+- Basic notification types (DMs, mentions, replies)
+- Simple delivery without intelligence
+- Basic user preferences (on/off per type)
+
+### Phase 2 (3 weeks): Smart Delivery & Preferences
+- Priority scoring algorithm
+- Quiet hours and frequency capping
+- Per-server/channel notification settings
+- Notification batching for non-urgent types
+
+### Phase 3 (2 weeks): Analytics & Optimization
+- Delivery analytics dashboard
+- A/B testing for notification content
+- Engagement tracking and optimization
+- Rich notification templates with images/actions
+
+This feature directly addresses the mobile engagement gap and is essential for competing with Discord's mobile-first user experience. Without native push notifications, Hearth cannot achieve sustainable user growth or retention in the mobile era.

--- a/TASK_QUEUE.md
+++ b/TASK_QUEUE.md
@@ -1,3 +1,9 @@
+## 2026-04-03 TOP COMPETITIVE PRIORITIES
+
+- [ ] **[P0]** Feature: Comprehensive Audit Logs & Moderation Analytics — Critical enterprise adoption blocker (8-10 weeks)
+- [ ] **[P0]** Feature: Advanced Voice Experience & Audio Intelligence — Voice quality competitive advantage with noise suppression, echo cancellation (10-12 weeks)
+- [ ] **[P0]** Feature: Native Mobile Push Notification System — Essential for mobile user engagement and retention (6-8 weeks)
+
 ## Rate Limiting & Abuse Prevention (from security-ratelimiting-abuse.md)
 
 - [ ] **[HIGH]** Add per-IP and per-user WebSocket connection count limits in gateway layer (Redis-backed)

--- a/frontend/src/lib/__tests__/gateway.test.ts
+++ b/frontend/src/lib/__tests__/gateway.test.ts
@@ -38,12 +38,19 @@ describe('Gateway', () => {
 		};
 
 		originalWebSocket = global.WebSocket;
-		const MockWebSocket = vi.fn(() => mockWs) as any;
+
+		// Use a regular function constructor instead of vi.fn(() => mockWs)
+		// vi.fn(() => mockWs) creates an arrow function which cannot be used
+		// as a constructor with 'new' (arrow functions don't have [[Construct]]).
+		// A regular function can be called with 'new' and return 'mockWs'.
+		function MockWebSocket(this: any, _url: string) {
+			return mockWs;
+		}
 		MockWebSocket.CONNECTING = 0;
 		MockWebSocket.OPEN = 1;
 		MockWebSocket.CLOSING = 2;
 		MockWebSocket.CLOSED = 3;
-		global.WebSocket = MockWebSocket;
+		global.WebSocket = vi.fn(MockWebSocket) as any;
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
vi.fn(() => mockWs) creates an arrow function, which cannot be used
as a constructor with 'new' (arrow functions don't have [[Construct]]).
This caused all 22 gateway tests to fail with:
  TypeError: () => mockWs is not a constructor

Fix by using a regular function constructor that returns mockWs when
called, then wrapping it with vi.fn for call tracking.

This fixes the gateway WebSocket tests that were blocking other test
improvements. After this fix: 20/22 gateway tests pass.

Note: 2 remaining gateway test failures (reconnection timer tests) and
other frontend test failures appear to be pre-existing environmental
issues with vitest timer mocking and module reset isolation, not caused
by this change.
