### PR TITLE
refactor(handlers): add interfaces for LiveKitVoiceHandler dependency injection

### DIFF
--- a/backend/internal/api/handlers/voice.go
+++ b/backend/internal/api/handlers/voice.go
@@ -10,18 +10,18 @@ import (
 
 // LiveKitVoiceHandler handles LiveKit voice channel operations
 type LiveKitVoiceHandler struct {
-	voiceService   *services.VoiceService
-	userService    *services.UserService
-	channelService *services.ChannelService
-	permService    *services.PermissionService
+	voiceService   services.VoiceServiceInterface
+	userService    services.UserServiceInterface
+	channelService services.ChannelServiceInterface
+	permService    services.VoicePermissionServiceInterface
 }
 
 // NewLiveKitVoiceHandler creates a new LiveKit voice handler
 func NewLiveKitVoiceHandler(
-	voiceService *services.VoiceService,
-	userService *services.UserService,
-	channelService *services.ChannelService,
-	permService *services.PermissionService,
+	voiceService services.VoiceServiceInterface,
+	userService services.UserServiceInterface,
+	channelService services.ChannelServiceInterface,
+	permService services.VoicePermissionServiceInterface,
 ) *LiveKitVoiceHandler {
 	return &LiveKitVoiceHandler{
 		voiceService:   voiceService,

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -299,3 +299,28 @@ func (s *QuotaService) CheckStorageQuota(ctx context.Context, userID uuid.UUID, 
 
 	return nil
 }
+
+// VoiceServiceInterface defines the interface for LiveKit voice operations
+type VoiceServiceInterface interface {
+	IsConfigured() bool
+	GenerateToken(ctx context.Context, userID uuid.UUID, channelID uuid.UUID, userName, displayName, avatarURL string) (*VoiceTokenResponse, error)
+	GetRoomParticipants(ctx context.Context, channelID uuid.UUID) ([]Participant, error)
+	DisconnectParticipant(ctx context.Context, channelID uuid.UUID, userID uuid.UUID) error
+	MuteParticipant(ctx context.Context, channelID uuid.UUID, userID uuid.UUID, muted bool) error
+}
+
+// UserServiceInterface defines the interface for user operations needed by voice handler
+type UserServiceInterface interface {
+	GetUser(ctx context.Context, userID uuid.UUID) (*models.User, error)
+}
+
+// ChannelServiceInterface defines the interface for channel operations needed by voice handler
+type ChannelServiceInterface interface {
+	GetChannel(ctx context.Context, channelID uuid.UUID) (*models.Channel, error)
+	GetServerChannels(ctx context.Context, serverID uuid.UUID, requesterID uuid.UUID) ([]*models.Channel, error)
+}
+
+// VoicePermissionServiceInterface defines the interface for permission operations needed by voice handler
+type VoicePermissionServiceInterface interface {
+	RequirePermission(ctx context.Context, serverID, userID uuid.UUID, permission int64) error
+}


### PR DESCRIPTION
Add VoiceServiceInterface, UserServiceInterface, ChannelServiceInterface,
and VoicePermissionServiceInterface to enable proper dependency injection
and mock-based unit testing for LiveKitVoiceHandler.

The handler previously used concrete service types, making it difficult
to write unit tests without a real database/LiveKit connection.
These interfaces follow the same pattern used by WebhookHandlers and
other handlers in the codebase.
