### PR TITLE
fix(config_test): add TestMain to set SECRET_KEY before tests run

### DIFF
--- a/TASK_QUEUE.md
+++ b/TASK_QUEUE.md
@@ -1,3 +1,8 @@
+## 2026-04-03 GitHub Issues Pipeline
+
+**Status**: No open issues found in repository
+**Action**: HEARTBEAT_OK - No unclaimed issues to process
+
 ## 2026-04-03 TOP COMPETITIVE PRIORITIES
 
 - [ ] **[P0]** Feature: Comprehensive Audit Logs & Moderation Analytics — Critical enterprise adoption blocker (8-10 weeks)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -6,6 +6,16 @@ import (
 	"time"
 )
 
+// TestMain sets up the test environment before running tests.
+// This ensures SECRET_KEY is set before any test that calls Load().
+func TestMain(m *testing.M) {
+	// Ensure SECRET_KEY is set for tests that call Load()
+	// This prevents panics from getRequiredEnv("SECRET_KEY") during test setup
+	os.Setenv("SECRET_KEY", "test-secret-key-for-unit-tests")
+	code := m.Run()
+	os.Exit(code)
+}
+
 func TestLoad(t *testing.T) {
 	// Clear any existing env vars that might affect the test
 	oldVars := map[string]string{}


### PR DESCRIPTION
## Summary
Adds a `TestMain` function to `backend/internal/config/config_test.go` that sets the `SECRET_KEY` environment variable before any tests run.

## Problem
CI was failing with:
```
panic: required environment variable SECRET_KEY is not set
```

This can occur when test setup or panic recovery mechanisms call `Load()` before individual test setup sets `SECRET_KEY`.

## Solution
`TestMain` runs before any test functions and sets `SECRET_KEY` globally for the entire test package, ensuring it's always set before `Load()` is called.

## Testing
- All config tests pass locally with and without race detector
- The fix is minimal (10 lines added)