### PR TITLE
fix(security): restore correct G115 guard in CheckMentionAbuse

### DIFF
--- a/backend/internal/services/content_filter.go
+++ b/backend/internal/services/content_filter.go
@@ -159,7 +159,7 @@ func CheckMentionAbuse(content string, mentionLimit int) bool {
 		if r == '@' && !inWord {
 			mentionCount++
 			inWord = true
-		} else if r <= 255 && !isAlphanumeric(byte(r)) {
+		} else if r > 255 || !isAlphanumeric(byte(r)) {
 			inWord = false
 		}
 	}


### PR DESCRIPTION
The previous commit 5377c7b incorrectly changed the condition from
'r > 255 || !isAlphanumeric(byte(r))' to 'r <= 255 && !isAlphanumeric(byte(r))'.
This introduced a logic bug where Unicode characters (r > 255) would not
properly end mentions, allowing potential mention abuse bypass.

The correct fix for G115 is 'r > 255 ||' which:
1. Prevents integer overflow by short-circuiting when r > 255
   (before byte() cast that would truncate)
2. Correctly handles non-ASCII characters by ending mentions when r > 255

Fixes regression introduced in 5377c7b.
