### PR TITLE
fix(tests): add missing GetThreadCount, GetThreadsPaginated, GetTotalMessageCount to mock ThreadRepository

### DIFF
--- a/backend/internal/services/thread_auto_archive_service_test.go
+++ b/backend/internal/services/thread_auto_archive_service_test.go
@@ -127,7 +127,15 @@ func (m *simpleMockThreadRepo) GetActiveByChannelID(ctx context.Context, channel
 	return nil, nil
 }
 
+func (m *simpleMockThreadRepo) GetThreadsPaginated(ctx context.Context, channelID uuid.UUID, sortOrder int, limit, offset int, includeArchived bool) ([]models.Thread, int, error) {
+	return nil, 0, nil
+}
+
 func (m *simpleMockThreadRepo) GetThreadCount(ctx context.Context, channelID uuid.UUID, includeArchived bool) (int, error) {
+	return 0, nil
+}
+
+func (m *simpleMockThreadRepo) GetTotalMessageCount(ctx context.Context, channelID uuid.UUID) (int, error) {
 	return 0, nil
 }
 

--- a/backend/internal/services/thread_auto_archive_worker_test.go
+++ b/backend/internal/services/thread_auto_archive_worker_test.go
@@ -137,7 +137,15 @@ func (m *simpleMockThreadRepoForWorker) GetActiveByChannelID(ctx context.Context
 	return m.GetByChannelID(ctx, channelID)
 }
 
+func (m *simpleMockThreadRepoForWorker) GetThreadsPaginated(ctx context.Context, channelID uuid.UUID, sortOrder int, limit, offset int, includeArchived bool) ([]models.Thread, int, error) {
+	return nil, 0, nil
+}
+
 func (m *simpleMockThreadRepoForWorker) GetThreadCount(ctx context.Context, channelID uuid.UUID, includeArchived bool) (int, error) {
+	return 0, nil
+}
+
+func (m *simpleMockThreadRepoForWorker) GetTotalMessageCount(ctx context.Context, channelID uuid.UUID) (int, error) {
 	return 0, nil
 }
 

--- a/backend/internal/services/thread_service_test.go
+++ b/backend/internal/services/thread_service_test.go
@@ -18,6 +18,9 @@ type mockThreadRepository struct {
 	deleteFunc                func(ctx context.Context, id uuid.UUID) error
 	getByChannelIDFunc        func(ctx context.Context, channelID uuid.UUID) ([]*models.Thread, error)
 	getActiveByChannelIDFunc  func(ctx context.Context, channelID uuid.UUID) ([]*models.Thread, error)
+	getThreadsPaginatedFunc    func(ctx context.Context, channelID uuid.UUID, sortOrder int, limit, offset int, includeArchived bool) ([]models.Thread, int, error)
+	getThreadCountFunc         func(ctx context.Context, channelID uuid.UUID, includeArchived bool) (int, error)
+	getTotalMessageCountFunc   func(ctx context.Context, channelID uuid.UUID) (int, error)
 	archiveFunc               func(ctx context.Context, id uuid.UUID) error
 	unarchiveFunc             func(ctx context.Context, id uuid.UUID) error
 	addMemberFunc             func(ctx context.Context, threadID, userID uuid.UUID) error
@@ -73,6 +76,27 @@ func (m *mockThreadRepository) GetActiveByChannelID(ctx context.Context, channel
 		return m.getActiveByChannelIDFunc(ctx, channelID)
 	}
 	return []*models.Thread{}, nil
+}
+
+func (m *mockThreadRepository) GetThreadsPaginated(ctx context.Context, channelID uuid.UUID, sortOrder int, limit, offset int, includeArchived bool) ([]models.Thread, int, error) {
+	if m.getThreadsPaginatedFunc != nil {
+		return m.getThreadsPaginatedFunc(ctx, channelID, sortOrder, limit, offset, includeArchived)
+	}
+	return nil, 0, nil
+}
+
+func (m *mockThreadRepository) GetThreadCount(ctx context.Context, channelID uuid.UUID, includeArchived bool) (int, error) {
+	if m.getThreadCountFunc != nil {
+		return m.getThreadCountFunc(ctx, channelID, includeArchived)
+	}
+	return 0, nil
+}
+
+func (m *mockThreadRepository) GetTotalMessageCount(ctx context.Context, channelID uuid.UUID) (int, error) {
+	if m.getTotalMessageCountFunc != nil {
+		return m.getTotalMessageCountFunc(ctx, channelID)
+	}
+	return 0, nil
 }
 
 func (m *mockThreadRepository) Archive(ctx context.Context, id uuid.UUID) error {


### PR DESCRIPTION
Fixes golangci-lint failure (run 23947917405) on commit `093286697c676d743ba4fac0f5f68fd50de522ec`.

The `simpleMockThreadRepo`, `simpleMockThreadRepoForWorker`, and `mockThreadRepository` mock structs were missing three methods required by the `ThreadRepository` interface:
- `GetThreadCount`
- `GetThreadsPaginated`
- `GetTotalMessageCount`

Added stub implementations for all three methods on all three mock structs.

Note: The main branch already contains equivalent fixes via commits `ba2d949` and `3ca5d59`. This PR provides the same fix as a single coherent branch from the original failing commit.