### PR TITLE
fix(slashCommands): handle multi-word string args and fix autocomplete test

### DIFF
--- a/frontend/src/lib/__tests__/slashCommands.test.ts
+++ b/frontend/src/lib/__tests__/slashCommands.test.ts
@@ -193,7 +193,8 @@ describe('Slash Commands Store Functions', () => {
 				{ id: '3', name: 'party', description: 'Party mode', type: 1, application_id: 'app', version: 'v1', default_permission: true, created_at: '', updated_at: '' }
 			];
 
-			const results = getAutocompleteSuggestions('/p', commands as any);
+			// Use '/pin' to uniquely match 'ping' (not 'party' which starts with 'p' but doesn't match 'pin')
+			const results = getAutocompleteSuggestions('/pin', commands as any);
 			expect(results.length).toBe(1);
 			expect(results[0].command.name).toBe('ping');
 		});

--- a/frontend/src/lib/services/slashCommands.ts
+++ b/frontend/src/lib/services/slashCommands.ts
@@ -351,6 +351,18 @@ export function parseCommandInput(input: string, command: SlashCommand): {
 				errors.push(`Unexpected value: ${part}`);
 				continue;
 			}
+
+			// For String type, collect all remaining args as the value
+			if (positionalOpt.type === 3) {
+				const remaining = parts.slice(i).join(' ');
+				const parsed = parseOptionValue(3, remaining);
+				options[positionalOpt.name] = parsed.value;
+				if (!parsed.valid) {
+					errors.push(`Invalid value for ${positionalOpt.name}: ${remaining}`);
+				}
+				break; // All remaining args consumed for string option
+			}
+
 			const parsed = parseOptionValue(positionalOpt.type, part);
 			options[positionalOpt.name] = parsed.value;
 			if (!parsed.valid) {


### PR DESCRIPTION
## Summary

Fixes 2 failing tests in :

1. **String type options now collect remaining args**: When a positional argument is a String type (type 3), the parser now collects all remaining arguments and joins them with spaces. This fixes parsing of commands like  where the reason should be  (two words).

2. **Fixed autocomplete partial name test**: Changed test input from  to  because  matches both  AND  (both start with 'p'). Using  uniquely matches only .

## Changes

- : In , when encountering a String type positional option, collect all remaining args and break (don't process them separately)
- : Changed  to  in the autocomplete test

## Testing

```bash
cd frontend && bun run test --run src/lib/__tests__/slashCommands.test.ts
# All 13 tests pass
```