### PR TITLE
security: fix G115 integer overflow in content filter via proper Unicode handling

### DIFF
--- a/backend/internal/services/content_filter.go
+++ b/backend/internal/services/content_filter.go
@@ -3,6 +3,7 @@ package services
 import (
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // CheckKeywordMatch checks if content matches any of the keywords.
@@ -159,7 +160,7 @@ func CheckMentionAbuse(content string, mentionLimit int) bool {
 		if r == '@' && !inWord {
 			mentionCount++
 			inWord = true
-		} else if r > 255 || !isAlphanumeric(byte(r)) {
+		} else if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
 			inWord = false
 		}
 	}


### PR DESCRIPTION
- Replace byte-level isAlphanumeric check with unicode.IsLetter/unicode.IsDigit
- Remove potential rune truncation when processing characters > 255
- Fix CheckMentionAbuse to properly handle Unicode characters

Fixes G115 (CWE-190 Integer Overflow) in content_filter.go
