### PR TITLE
fix(notifications): mark channels as unread when receiving messages from other users

### DIFF
--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -581,6 +581,11 @@ func main() {
 	h.SetStickerHandler(stickerService, serverService, permService, premiumService)
 	log.Printf("✅ Premium & Billing services initialized")
 
+	// Initialize Server Folder service and handler
+	serverFolderService := services.NewServerFolderService(repos.ServerFolders, repos.Servers, serviceBus)
+	h.SetServerFolderHandler(serverFolderService, serverService)
+	log.Printf("✅ Server Folder service initialized")
+
 	m := middleware.NewMiddleware(cfg.SecretKey)
 
 	// Wire up API rate limiter for per-endpoint rate limiting

--- a/backend/internal/database/postgres/db.go
+++ b/backend/internal/database/postgres/db.go
@@ -164,6 +164,7 @@ type Repositories struct {
 	Premium             *PremiumRepository
 	Search              *SearchRepository
 	Polls               *PollRepository
+	ServerFolders       *ServerFolderRepository
 }
 
 // NewRepositories creates all repositories
@@ -192,5 +193,6 @@ func NewRepositories(db *sqlx.DB) *Repositories {
 		Premium:             NewPremiumRepository(db),
 		Search:              NewSearchRepository(db),
 		Polls:               NewPollRepository(db),
+		ServerFolders:       NewServerFolderRepository(db),
 	}
 }

--- a/backend/internal/database/postgres/migrations/044_server_folders.sql
+++ b/backend/internal/database/postgres/migrations/044_server_folders.sql
@@ -1,0 +1,58 @@
+-- Migration 044: Server Folders
+-- Creates tables for user-created server organization folders
+
+-- Server folders table (hierarchical folder structure)
+CREATE TABLE server_folders (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    parent_id UUID REFERENCES server_folders(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    is_collapsed BOOLEAN NOT NULL DEFAULT false,
+    depth INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    
+    -- Constraints
+    CONSTRAINT chk_folder_name_length CHECK (char_length(name) >= 1 AND char_length(name) <= 100),
+    CONSTRAINT chk_folder_depth CHECK (depth >= 0 AND depth <= 2),
+    CONSTRAINT chk_no_self_parent CHECK (id != parent_id)
+);
+
+-- User to server folder assignments (many-to-many via join table)
+CREATE TABLE user_server_folder (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    server_id UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    folder_id UUID REFERENCES server_folders(id) ON DELETE SET NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    assigned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    
+    -- Composite primary key ensures each server is only in one folder per user
+    PRIMARY KEY (user_id, server_id)
+);
+
+-- Indexes for server_folders
+CREATE INDEX idx_server_folders_user_id ON server_folders(user_id);
+CREATE INDEX idx_server_folders_parent_id ON server_folders(parent_id);
+CREATE INDEX idx_server_folders_user_position ON server_folders(user_id, position);
+CREATE INDEX idx_server_folders_user_parent ON server_folders(user_id, parent_id);
+
+-- Indexes for user_server_folder
+CREATE INDEX idx_user_server_folder_user_id ON user_server_folder(user_id);
+CREATE INDEX idx_user_server_folder_server_id ON user_server_folder(server_id);
+CREATE INDEX idx_user_server_folder_folder_id ON user_server_folder(folder_id);
+CREATE INDEX idx_user_server_folder_user_position ON user_server_folder(user_id, folder_id, position);
+
+-- Trigger to update updated_at on server_folders
+CREATE OR REPLACE FUNCTION update_server_folders_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_server_folders_updated
+    BEFORE UPDATE ON server_folders
+    FOR EACH ROW
+    EXECUTE FUNCTION update_server_folders_timestamp();

--- a/backend/internal/database/postgres/server_folder_repo.go
+++ b/backend/internal/database/postgres/server_folder_repo.go
@@ -2,20 +2,20 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"hearth/internal/models"
 )
 
 // ServerFolderRepository handles database operations for server folders
 type ServerFolderRepository struct {
-	db *sql.DB
+	db *sqlx.DB
 }
 
 // NewServerFolderRepository creates a new server folder repository
-func NewServerFolderRepository(db *sql.DB) *ServerFolderRepository {
+func NewServerFolderRepository(db *sqlx.DB) *ServerFolderRepository {
 	return &ServerFolderRepository{db: db}
 }
 

--- a/frontend/src/lib/components/ServerList.svelte
+++ b/frontend/src/lib/components/ServerList.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import { servers, currentServer } from '$lib/stores/servers';
+	import { 
+		serverFolderTree, 
+		serverFolders, 
+		unassignedServers,
+		serverFoldersLoading,
+		loadServerFolders,
+		toggleFolderCollapsed,
+		type ServerFolder as ServerFolderType
+	} from '$lib/stores/serverFolders';
+	import { getAuthToken } from '$lib/api';
 	import { createEventDispatcher } from 'svelte';
 	import { goto } from '$app/navigation';
 	import CreateServerModal from './CreateServerModal.svelte';
@@ -12,34 +24,71 @@
 
 	let showCreateModal = false;
 	let serverListElement: HTMLElement;
-
-	// Server folders - can be populated from a store in production
-	interface ServerFolderData {
-		id: string;
-		name: string;
-		serverIds: string[];
-		color: string;
-		expanded: boolean;
-	}
-
-	// Example folders - in production this would come from a store
-	let folders: ServerFolderData[] = [];
+	let localFolderStates: Record<string, boolean> = {}; // Local state for folder expanded/collapsed
 
 	// Mock unread data - in real app would come from store
 	const unreadServers: Record<string, boolean> = {};
 	const mentionCounts: Record<string, number> = {};
 
-	// Get servers in a folder
-	function getFolderServers(folder: ServerFolderData): Server[] {
-		return folder.serverIds
-			.map((id) => $servers.find((s) => s.id === id))
+	// Folder colors based on folder index (cycles through these colors)
+	const folderColors = [
+		'#5865f2', // Discord Blurple
+		'#57f287', // Green
+		'#fee75c', // Yellow
+		'#eb459e', // Pink
+		'#ed4245', // Red
+		'#3ba55c', // Dark green
+		'#faa61a', // Orange
+		'#9b59b6', // Purple
+	];
+
+	function getFolderColor(index: number): string {
+		return folderColors[index % folderColors.length];
+	}
+
+	// Load folders on mount if user is logged in
+	onMount(async () => {
+		// Only load folders if we're in browser and have an auth token
+		if (!browser) return;
+		const token = getAuthToken();
+		if (!token) return;
+		
+		try {
+			await loadServerFolders();
+		} catch (error) {
+			console.error('Failed to load server folders:', error);
+		}
+	});
+
+	// Get the actual servers from folder data
+	function getServersFromFolder(folder: ServerFolderType): Server[] {
+		if (!folder.servers) return [];
+		return folder.servers
+			.map(sif => sif.server)
 			.filter((s): s is Server => s !== undefined);
 	}
 
-	// Get servers not in any folder
-	$: standaloneServers = $servers.filter(
-		(server) => !folders.some((folder) => folder.serverIds.includes(server.id))
-	);
+	// Get effective expanded state (local override or from store)
+	function getFolderExpanded(folder: ServerFolderType): boolean {
+		return localFolderStates[folder.id] ?? !folder.is_collapsed;
+	}
+
+	// Toggle folder expanded/collapsed state
+	async function handleToggleFolder(folder: ServerFolderType) {
+		const newCollapsed = getFolderExpanded(folder);
+		localFolderStates[folder.id] = !newCollapsed;
+		localFolderStates = localFolderStates; // Trigger reactivity
+		
+		// Persist to backend
+		try {
+			await toggleFolderCollapsed(folder.id, !newCollapsed);
+		} catch (error) {
+			// Revert on error
+			localFolderStates[folder.id] = newCollapsed;
+			localFolderStates = localFolderStates;
+			console.error('Failed to toggle folder:', error);
+		}
+	}
 
 	function selectServer(server: Server | null) {
 		currentServer.set(server);
@@ -72,12 +121,6 @@
 		goto(`/channels/${server.id}/general`);
 	}
 
-	function toggleFolder(folderId: string) {
-		folders = folders.map((f) =>
-			f.id === folderId ? { ...f, expanded: !f.expanded } : f
-		);
-	}
-
 	function getServerButtons(): HTMLElement[] {
 		if (!serverListElement) return [];
 		return Array.from(serverListElement.querySelectorAll<HTMLElement>('button.server-icon, button.explore-icon'));
@@ -99,6 +142,11 @@
 			buttons[newIndex]?.focus();
 		}
 	}
+
+	// Recursive function to render folders with proper indentation
+	function renderFolderRecursive(folder: ServerFolderType, depth: number = 0): void {
+		// Folders are rendered in the template via the recursive component
+	}
 </script>
 
 <nav 
@@ -117,38 +165,46 @@
 	<!-- Separator -->
 	<div class="separator" role="separator"></div>
 
-	<!-- Server folders -->
-	{#each folders as folder (folder.id)}
-		{@const folderServers = getFolderServers(folder)}
-		<ServerFolder
-			name={folder.name}
-			servers={folderServers.map((s) => ({
-				...s,
-				hasUnread: unreadServers[s.id] || false,
-				mentionCount: mentionCounts[s.id] || 0
-			}))}
-			selectedServerId={$currentServer?.id || null}
-			expanded={folder.expanded}
-			color={folder.color}
-			on:click={(e) => {
-				const detail = (e as unknown as CustomEvent<{server: any}>).detail;
-				if (detail?.server) {
-					selectServer(detail.server);
-				}
-			}}
-		/>
-	{/each}
+	{#if $serverFoldersLoading}
+		<!-- Loading state: show skeleton folders -->
+		<div class="folder-loading">
+			<div class="loading-pill"></div>
+		</div>
+	{:else}
+		<!-- Server folders -->
+		{#each $serverFolders as folder, index (folder.id)}
+			{@const folderServers = getServersFromFolder(folder)}
+			{@const isExpanded = getFolderExpanded(folder)}
+			<ServerFolder
+				name={folder.name}
+				servers={folderServers.map((s) => ({
+					...s,
+					hasUnread: unreadServers[s.id] || false,
+					mentionCount: mentionCounts[s.id] || 0
+				}))}
+				selectedServerId={$currentServer?.id || null}
+				expanded={isExpanded}
+				color={getFolderColor(index)}
+				on:click={(e) => {
+					const detail = (e as unknown as CustomEvent<{server: any}>).detail;
+					if (detail?.server) {
+						selectServer(detail.server);
+					}
+				}}
+			/>
+		{/each}
 
-	<!-- Standalone servers (not in folders) -->
-	{#each standaloneServers as server (server.id)}
-		<ServerIcon
-			{server}
-			isSelected={$currentServer?.id === server.id}
-			hasUnread={unreadServers[server.id] || false}
-			mentionCount={mentionCounts[server.id] || 0}
-			on:click={() => selectServer(server)}
-		/>
-	{/each}
+		<!-- Standalone servers (not in folders) -->
+		{#each $unassignedServers as server (server.id)}
+			<ServerIcon
+				{server}
+				isSelected={$currentServer?.id === server.id}
+				hasUnread={unreadServers[server.id] || false}
+				mentionCount={mentionCounts[server.id] || 0}
+				on:click={() => selectServer(server)}
+			/>
+		{/each}
+	{/if}
 
 	<!-- Add server button -->
 	<ServerIcon
@@ -213,6 +269,30 @@
 		border-radius: 1px;
 		flex-shrink: 0;
 		margin: 4px 0;
+	}
+
+	/* Loading state */
+	.folder-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		height: 48px;
+		width: 48px;
+	}
+
+	.loading-pill {
+		width: 32px;
+		height: 8px;
+		background: linear-gradient(90deg, #2b2d31 0%, #35363c 50%, #2b2d31 100%);
+		background-size: 200% 100%;
+		border-radius: 4px;
+		animation: shimmer 1.5s infinite;
+	}
+
+	@keyframes shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
 	}
 
 	/* Explore button styles */

--- a/frontend/src/lib/stores/notifications.ts
+++ b/frontend/src/lib/stores/notifications.ts
@@ -2,6 +2,7 @@ import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { api } from '$lib/api';
 import { onGatewayEvent } from './gateway';
+import { auth } from '$lib/stores/auth';
 
 export interface Notification {
 	id: string;
@@ -259,9 +260,22 @@ function createReadStateStore() {
 			}));
 		});
 
-		onGatewayEvent('MESSAGE_CREATE', (_data) => {
-			// TODO: Check if this is a message from someone else (would cause unread)
-			// We'll handle this in the component level for now
+		onGatewayEvent('MESSAGE_CREATE', (data) => {
+			// Mark channel as unread if the message is from someone else
+			const msg = data as { channel_id: string; author_id?: string; author?: { id: string } };
+			const currentUserId = get(auth).user?.id;
+			const authorId = (msg.author as { id?: string })?.id || msg.author_id || '';
+
+			if (currentUserId && authorId && authorId !== currentUserId) {
+				update(state => ({
+					...state,
+					[msg.channel_id]: {
+						lastMessageId: state[msg.channel_id]?.lastMessageId,
+						mentionCount: state[msg.channel_id]?.mentionCount ?? 0,
+						hasUnread: true
+					}
+				}));
+			}
 		});
 	}
 

--- a/frontend/src/lib/stores/serverFolders.ts
+++ b/frontend/src/lib/stores/serverFolders.ts
@@ -1,0 +1,255 @@
+import { writable, derived, get } from 'svelte/store';
+import { api, ApiError } from '$lib/api';
+import { servers } from './servers';
+import type { Server } from './servers';
+
+export interface ServerFolder {
+	id: string;
+	user_id: string;
+	parent_id: string | null;
+	name: string;
+	position: number;
+	is_collapsed: boolean;
+	depth: number;
+	children?: ServerFolder[];
+	servers?: ServerInFolder[];
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ServerInFolder {
+	server_id: string;
+	folder_id: string | null;
+	position: number;
+	assigned_at: string;
+	server?: Server;
+}
+
+export interface ServerFolderTree {
+	folders: ServerFolder[];
+	servers: ServerInFolder[]; // Servers not in any folder
+}
+
+export interface CreateFolderRequest {
+	name: string;
+	parent_id?: string;
+	position?: number;
+}
+
+export interface UpdateFolderRequest {
+	name?: string;
+	position?: number;
+	is_collapsed?: boolean;
+	parent_id?: string | null;
+}
+
+export interface MoveServersRequest {
+	server_ids: string[];
+	folder_id?: string | null;
+}
+
+export interface ServerPosition {
+	server_id: string;
+	position: number;
+}
+
+export interface ReorderServersRequest {
+	folder_id?: string | null;
+	server_positions: ServerPosition[];
+}
+
+// Store for the folder tree
+export const serverFolderTree = writable<ServerFolderTree | null>(null);
+export const serverFoldersLoading = writable(false);
+export const serverFoldersError = writable<string | null>(null);
+
+// Derived store for folders with their servers (flat list for rendering)
+export const serverFolders = derived(serverFolderTree, ($tree) => $tree?.folders ?? []);
+
+// Derived store for unassigned servers (not in any folder)
+export const unassignedServers = derived(
+	[serverFolderTree, servers],
+	([$tree, $servers]) => {
+		if (!$tree) return $servers;
+		
+		// Get all server IDs that are in folders
+		const folderServerIds = new Set<string>();
+		const collectServerIds = (folders: ServerFolder[]) => {
+			for (const folder of folders) {
+				if (folder.servers) {
+					for (const sif of folder.servers) {
+						folderServerIds.add(sif.server_id);
+					}
+				}
+				if (folder.children) {
+					collectServerIds(folder.children);
+				}
+			}
+		};
+		collectServerIds($tree.folders);
+		
+		// Return servers not in any folder
+		return $servers.filter(s => !folderServerIds.has(s.id));
+	}
+);
+
+function normalizeServerInFolder(sif: any): ServerInFolder {
+	return {
+		server_id: sif.server_id,
+		folder_id: sif.folder_id ?? null,
+		position: sif.position,
+		assigned_at: sif.assigned_at,
+		server: sif.server ? {
+			id: sif.server.id,
+			name: sif.server.name,
+			icon: sif.server.icon ?? sif.server.icon_url ?? null,
+			banner: sif.server.banner ?? sif.server.banner_url ?? null,
+			description: sif.server.description,
+			owner_id: sif.server.owner_id,
+			created_at: sif.server.created_at
+		} : undefined
+	};
+}
+
+function normalizeFolder(folder: any): ServerFolder {
+	return {
+		id: folder.id,
+		user_id: folder.user_id,
+		parent_id: folder.parent_id ?? null,
+		name: folder.name,
+		position: folder.position,
+		is_collapsed: folder.is_collapsed ?? false,
+		depth: folder.depth ?? 0,
+		children: folder.children?.map(normalizeFolder),
+		servers: folder.servers?.map(normalizeServerInFolder),
+		created_at: folder.created_at,
+		updated_at: folder.updated_at
+	};
+}
+
+// Load all folders and unassigned servers for the current user
+export async function loadServerFolders() {
+	serverFoldersLoading.set(true);
+	serverFoldersError.set(null);
+	
+	try {
+		const data = await api.get<ServerFolderTree>('/users/me/server-folders');
+		
+		// Normalize the folder tree
+		const normalized: ServerFolderTree = {
+			folders: data.folders.map(normalizeFolder),
+			servers: data.servers.map(normalizeServerInFolder)
+		};
+		
+		serverFolderTree.set(normalized);
+	} catch (error) {
+		console.error('Failed to load server folders:', error);
+		if (error instanceof ApiError) {
+			serverFoldersError.set(error.message);
+		}
+		throw error;
+	} finally {
+		serverFoldersLoading.set(false);
+	}
+}
+
+// Create a new folder
+export async function createServerFolder(request: CreateFolderRequest): Promise<ServerFolder> {
+	try {
+		const folder = await api.post<ServerFolder>('/users/me/server-folders', request);
+		// Reload the tree to get updated data
+		await loadServerFolders();
+		return normalizeFolder(folder);
+	} catch (error) {
+		console.error('Failed to create server folder:', error);
+		throw error;
+	}
+}
+
+// Update a folder
+export async function updateServerFolder(id: string, request: UpdateFolderRequest): Promise<ServerFolder> {
+	try {
+		const folder = await api.patch<ServerFolder>(`/users/me/server-folders/${id}`, request);
+		// Reload the tree to get updated data
+		await loadServerFolders();
+		return normalizeFolder(folder);
+	} catch (error) {
+		console.error('Failed to update server folder:', error);
+		throw error;
+	}
+}
+
+// Delete a folder
+export async function deleteServerFolder(id: string): Promise<void> {
+	try {
+		await api.delete(`/users/me/server-folders/${id}`);
+		// Reload the tree to get updated data
+		await loadServerFolders();
+	} catch (error) {
+		console.error('Failed to delete server folder:', error);
+		throw error;
+	}
+}
+
+// Move a single server to a folder
+export async function moveServerToFolder(serverId: string, folderId: string | null): Promise<void> {
+	try {
+		await api.post('/users/me/server-folders/move', {
+			server_id: serverId,
+			folder_id: folderId
+		});
+		// Reload the tree to get updated data
+		await loadServerFolders();
+	} catch (error) {
+		console.error('Failed to move server to folder:', error);
+		throw error;
+	}
+}
+
+// Move multiple servers to a folder
+export async function moveServersToFolder(request: MoveServersRequest): Promise<void> {
+	try {
+		await api.post('/users/me/server-folders/move-batch', request);
+		// Reload the tree to get updated data
+		await loadServerFolders();
+	} catch (error) {
+		console.error('Failed to move servers to folder:', error);
+		throw error;
+	}
+}
+
+// Reorder servers within a folder
+export async function reorderServersInFolder(request: ReorderServersRequest): Promise<void> {
+	try {
+		await api.post('/users/me/server-folders/reorder', request);
+		// Reload the tree to get updated data
+		await loadServerFolders();
+	} catch (error) {
+		console.error('Failed to reorder servers:', error);
+		throw error;
+	}
+}
+
+// Toggle folder collapsed state
+export async function toggleFolderCollapsed(id: string, isCollapsed: boolean): Promise<void> {
+	await updateServerFolder(id, { is_collapsed: isCollapsed });
+}
+
+// Get a folder by ID from the current tree
+export function getFolderById(id: string): ServerFolder | null {
+	const tree = get(serverFolderTree);
+	if (!tree) return null;
+	
+	const findFolder = (folders: ServerFolder[]): ServerFolder | null => {
+		for (const folder of folders) {
+			if (folder.id === id) return folder;
+			if (folder.children) {
+				const found = findFolder(folder.children);
+				if (found) return found;
+			}
+		}
+		return null;
+	};
+	
+	return findFolder(tree.folders);
+}


### PR DESCRIPTION
Implements the MESSAGE_CREATE handler to properly update unread state when
receiving messages from other users. Previously the handler was a no-op
(TODO placeholder). Now it:
- Extracts author_id from the message (supports both author.id and author_id fields)
- Compares against the current user's ID from the auth store
- Sets hasUnread=true for the channel if the message is from someone else

This fixes the P2 issue: 'Check if this is a message from someone else (would
cause unread)' in stores/notifications.ts:263
