### PR TITLE
feat(unread): add server-level unread badge tracking

### DIFF
--- a/frontend/src/lib/components/ServerList.svelte
+++ b/frontend/src/lib/components/ServerList.svelte
@@ -11,6 +11,11 @@
 		toggleFolderCollapsed,
 		type ServerFolder as ServerFolderType
 	} from '$lib/stores/serverFolders';
+	import { 
+		hasUnreadForServer, 
+		mentionCountForServer,
+		fetchServerUnreadState 
+	} from '$lib/stores/unread';
 	import { getAuthToken } from '$lib/api';
 	import { createEventDispatcher } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -25,10 +30,6 @@
 	let showCreateModal = false;
 	let serverListElement: HTMLElement;
 	let localFolderStates: Record<string, boolean> = {}; // Local state for folder expanded/collapsed
-
-	// Mock unread data - in real app would come from store
-	const unreadServers: Record<string, boolean> = {};
-	const mentionCounts: Record<string, number> = {};
 
 	// Folder colors based on folder index (cycles through these colors)
 	const folderColors = [
@@ -55,8 +56,9 @@
 		
 		try {
 			await loadServerFolders();
+			await fetchServerUnreadState();
 		} catch (error) {
-			console.error('Failed to load server folders:', error);
+			console.error('Failed to load server data:', error);
 		}
 	});
 
@@ -179,8 +181,8 @@
 				name={folder.name}
 				servers={folderServers.map((s) => ({
 					...s,
-					hasUnread: unreadServers[s.id] || false,
-					mentionCount: mentionCounts[s.id] || 0
+					hasUnread: $hasUnreadForServer.get(s.id) ?? false,
+					mentionCount: $mentionCountForServer.get(s.id) ?? 0
 				}))}
 				selectedServerId={$currentServer?.id || null}
 				expanded={isExpanded}
@@ -199,8 +201,8 @@
 			<ServerIcon
 				{server}
 				isSelected={$currentServer?.id === server.id}
-				hasUnread={unreadServers[server.id] || false}
-				mentionCount={mentionCounts[server.id] || 0}
+				hasUnread={$hasUnreadForServer.get(server.id) ?? false}
+				mentionCount={$mentionCountForServer.get(server.id) ?? 0}
 				on:click={() => selectServer(server)}
 			/>
 		{/each}

--- a/frontend/src/lib/stores/unread.test.ts
+++ b/frontend/src/lib/stores/unread.test.ts
@@ -20,6 +20,10 @@ import {
 	fetchUnreadState,
 	markChannelRead,
 	updateChannelUnread,
+	updateServerUnread,
+	hasUnreadForServer,
+	mentionCountForServer,
+	fetchServerUnreadState,
 	type UnreadState,
 	type UnreadChannel
 } from './unread';
@@ -226,6 +230,101 @@ describe('Unread Store', () => {
 			expect(unread.has('ch-1')).toBe(true);
 			expect(unread.has('ch-2')).toBe(false);
 			expect(unread.has('ch-3')).toBe(true);
+		});
+	});
+});
+
+// ---------- Server-level Unread Tests ----------
+
+describe('Server-level Unread Store', () => {
+	beforeEach(() => {
+		unreadStore.set(makeUnreadState());
+		vi.clearAllMocks();
+	});
+
+	// ---------- updateServerUnread ----------
+
+	describe('updateServerUnread', () => {
+		it('should update server unread state', () => {
+			updateServerUnread('server-1', true, 5, 2);
+
+			expect(get(hasUnreadForServer).get('server-1')).toBe(true);
+			expect(get(mentionCountForServer).get('server-1')).toBe(2);
+		});
+
+		it('should update multiple servers independently', () => {
+			updateServerUnread('server-1', true, 5, 2);
+			updateServerUnread('server-2', false, 0, 0);
+			updateServerUnread('server-3', true, 10, 5);
+
+			expect(get(hasUnreadForServer).get('server-1')).toBe(true);
+			expect(get(hasUnreadForServer).get('server-2')).toBe(false);
+			expect(get(hasUnreadForServer).get('server-3')).toBe(true);
+			expect(get(mentionCountForServer).get('server-1')).toBe(2);
+			expect(get(mentionCountForServer).get('server-2')).toBe(0);
+			expect(get(mentionCountForServer).get('server-3')).toBe(5);
+		});
+
+		it('should overwrite previous server state', () => {
+			updateServerUnread('server-1', true, 5, 2);
+			updateServerUnread('server-1', false, 0, 0);
+
+			expect(get(hasUnreadForServer).get('server-1')).toBe(false);
+			expect(get(mentionCountForServer).get('server-1')).toBe(0);
+		});
+	});
+
+	// ---------- fetchServerUnreadState ----------
+
+	describe('fetchServerUnreadState', () => {
+		it('should fetch and aggregate server unread state', async () => {
+			// Mock server list
+			mockApi.get
+				.mockResolvedValueOnce([
+					{ id: 'server-1' },
+					{ id: 'server-2' }
+				])
+				// Mock server-1 unread
+				.mockResolvedValueOnce({
+					total_unread: 5,
+					total_mentions: 2,
+					channels: []
+				})
+				// Mock server-2 unread
+				.mockResolvedValueOnce({
+					total_unread: 0,
+					total_mentions: 0,
+					channels: []
+				});
+
+			await fetchServerUnreadState();
+
+			expect(get(hasUnreadForServer).get('server-1')).toBe(true);
+			expect(get(hasUnreadForServer).get('server-2')).toBe(false);
+			expect(get(mentionCountForServer).get('server-1')).toBe(2);
+			expect(get(mentionCountForServer).get('server-2')).toBe(0);
+		});
+
+		it('should handle partial server fetch failures gracefully', async () => {
+			mockApi.get
+				.mockResolvedValueOnce([
+					{ id: 'server-1' },
+					{ id: 'server-2' }
+				])
+				// server-1 fails (silently ignored in Promise.allSettled)
+				.mockRejectedValueOnce(new Error('Network error'))
+				// server-2 succeeds
+				.mockResolvedValueOnce({
+					total_unread: 3,
+					total_mentions: 1,
+					channels: []
+				});
+
+			await fetchServerUnreadState();
+
+			// server-2 should be set, server-1 should not be in the map (silently ignored)
+			expect(get(hasUnreadForServer).get('server-2')).toBe(true);
+			expect(get(hasUnreadForServer).get('server-1')).toBeUndefined();
 		});
 	});
 });

--- a/frontend/src/lib/stores/unread.ts
+++ b/frontend/src/lib/stores/unread.ts
@@ -1,5 +1,6 @@
 import { writable, derived, type Readable } from 'svelte/store';
 import { api } from '$lib/api';
+import { servers } from './servers';
 
 export interface UnreadChannel {
 	channel_id: string;
@@ -12,6 +13,14 @@ export interface UnreadState {
 	total_unread: number;
 	total_mentions: number;
 	channels: UnreadChannel[];
+}
+
+// Server-level unread info (from /servers/:id/unread endpoint)
+export interface ServerUnreadInfo {
+	server_id: string;
+	has_unread: boolean;
+	unread_count: number;
+	mention_count: number;
 }
 
 // Map of channel_id -> UnreadChannel
@@ -50,8 +59,55 @@ export const hasUnreadForChannel: Readable<Map<string, boolean>> = derived(
 	}
 );
 
+// Server-level unread state
+const serverUnreadMap = writable<Map<string, ServerUnreadInfo>>(new Map());
+
+// Exported server-level unread store
+export const serverUnreadStore = derived(
+	serverUnreadMap,
+	($map) => $map
+);
+
+// Derived store: Set of server IDs with unread messages
+export const unreadServerIds: Readable<Set<string>> = derived(
+	serverUnreadMap,
+	($map) => {
+		const unread = new Set<string>();
+		for (const [serverId, info] of $map) {
+			if (info.has_unread) {
+				unread.add(serverId);
+			}
+		}
+		return unread;
+	}
+);
+
+// Derived store: Map of server_id -> has_unread for quick lookup
+export const hasUnreadForServer: Readable<Map<string, boolean>> = derived(
+	serverUnreadMap,
+	($map) => {
+		const result = new Map<string, boolean>();
+		for (const [serverId, info] of $map) {
+			result.set(serverId, info.has_unread);
+		}
+		return result;
+	}
+);
+
+// Derived store: Map of server_id -> mention_count for badges
+export const mentionCountForServer: Readable<Map<string, number>> = derived(
+	serverUnreadMap,
+	($map) => {
+		const result = new Map<string, number>();
+		for (const [serverId, info] of $map) {
+			result.set(serverId, info.mention_count);
+		}
+		return result;
+	}
+);
+
 /**
- * Fetch unread state from the API
+ * Fetch unread state from the API (channel-level)
  */
 export async function fetchUnreadState(): Promise<void> {
 	try {
@@ -69,6 +125,49 @@ export async function fetchUnreadState(): Promise<void> {
 		});
 	} catch (error) {
 		console.error('Failed to fetch unread state:', error);
+	}
+}
+
+/**
+ * Fetch server-level unread state for all servers the user is in
+ * Calls /servers/:id/unread for each server and aggregates the results
+ */
+export async function fetchServerUnreadState(): Promise<void> {
+	try {
+		const serverList = await api.get<{ id: string }[]>('/users/@me/servers');
+		
+		// Fetch unread state for each server in parallel
+		const results = await Promise.allSettled(
+			serverList.map(async (server: { id: string }) => {
+				const unread = await api.get<{ 
+					total_unread: number; 
+					total_mentions: number;
+					channels: Array<{ channel_id: string; unread_count: number; mention_count: number }>;
+				}>(`/servers/${server.id}/unread`);
+				return {
+					serverId: server.id,
+					info: {
+						server_id: server.id,
+						has_unread: unread.total_unread > 0,
+						unread_count: unread.total_unread,
+						mention_count: unread.total_mentions
+					}
+				};
+			})
+		);
+
+		// Update the server unread map
+		serverUnreadMap.update((map) => {
+			const newMap = new Map<string, ServerUnreadInfo>();
+			for (const result of results) {
+				if (result.status === 'fulfilled') {
+					newMap.set(result.value.serverId, result.value.info);
+				}
+			}
+			return newMap;
+		});
+	} catch (error) {
+		console.error('Failed to fetch server unread state:', error);
 	}
 }
 
@@ -131,6 +230,21 @@ export function updateChannelUnread(channelId: string, hasUnread: boolean, unrea
 }
 
 /**
+ * Update server-level unread state (e.g., when a new message arrives in any channel)
+ */
+export function updateServerUnread(serverId: string, hasUnread: boolean, unreadCount: number, mentionCount: number): void {
+	serverUnreadMap.update((map) => {
+		map.set(serverId, {
+			server_id: serverId,
+			has_unread: hasUnread,
+			unread_count: unreadCount,
+			mention_count: mentionCount
+		});
+		return new Map(map);
+	});
+}
+
+/**
  * Get unread count for a specific channel
  */
 export function getUnreadCount(channelId: string): number {
@@ -154,4 +268,18 @@ export function getChannelUnread(channelId: string): boolean {
 		hasUnread = channel ? channel.unread_count > 0 : false;
 	})();
 	return hasUnread;
+}
+
+/**
+ * Get mention count for a specific server
+ */
+export function getServerMentionCount(serverId: string): number {
+	let count = 0;
+	serverUnreadMap.subscribe((map) => {
+		const info = map.get(serverId);
+		if (info) {
+			count = info.mention_count;
+		}
+	})();
+	return count;
 }


### PR DESCRIPTION
- Add ServerUnreadInfo interface for server-level unread state
- Add fetchServerUnreadState() to fetch and aggregate unread by server
- Add hasUnreadForServer and mentionCountForServer derived stores
- Add updateServerUnread() for real-time updates
- Update ServerList.svelte to use real unread data instead of mock
- Add comprehensive tests for server-level unread functionality

Fixes TASK_QUEUE.md: [P0] Unread Badges & Notification System
