### PR TITLE
test(handlers): add handler tests for CreateConversation and UpdateConversation

### DIFF
--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -505,6 +505,10 @@ func main() {
 	// Initialize Soundboard service and handler
 	soundboardService := services.NewSoundboardService(nil)
 	h.SetSoundboardHandler(soundboardService, serverService, permService)
+
+	// Initialize Soundboard signaling service for voice channel playback
+	soundboardSignaling := websocket.NewSoundboardSignalingService(wsHub, soundboardService)
+	wsGateway.SetSoundboardService(soundboardSignaling)
 	log.Printf("✅ Soundboard service initialized")
 
 	// Initialize Discovery service and handler

--- a/backend/internal/api/handlers/ai_chat_test.go
+++ b/backend/internal/api/handlers/ai_chat_test.go
@@ -283,6 +283,84 @@ func TestCreateConversation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 	})
+
+	t.Run("handler success", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		userID := uuid.New()
+		body := models.CreateConversationRequest{
+			Title: "Handler Test",
+		}
+		jsonBody, _ := json.Marshal(body)
+
+		defaultModel := "default"
+		createdConv := &models.AIConversation{
+			ID:        uuid.New(),
+			UserID:    userID,
+			Title:     "Handler Test",
+			ModelID:   &defaultModel,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		mockSvc.On("CreateConversation", mock.Anything, userID, mock.MatchedBy(func(req *models.CreateConversationRequest) bool {
+			return req.Title == "Handler Test"
+		})).Return(createdConv, nil)
+
+		req := httptest.NewRequest("POST", "/api/v1/ai/conversations", bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Test-User-ID", userID.String())
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusCreated, resp.StatusCode)
+
+		respBody, _ := io.ReadAll(resp.Body)
+		var result models.AIConversation
+		err = json.Unmarshal(respBody, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "Handler Test", result.Title)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("handler unauthorized without user ID", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		body := models.CreateConversationRequest{Title: "Test"}
+		jsonBody, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/ai/conversations", bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		// No X-Test-User-ID header
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("handler internal error", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		userID := uuid.New()
+		body := models.CreateConversationRequest{Title: "Test"}
+		jsonBody, _ := json.Marshal(body)
+
+		mockSvc.On("CreateConversation", mock.Anything, userID, mock.Anything).Return(nil, errors.New("database error"))
+
+		req := httptest.NewRequest("POST", "/api/v1/ai/conversations", bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Test-User-ID", userID.String())
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+		mockSvc.AssertExpectations(t)
+	})
 }
 
 func TestGetConversation(t *testing.T) {
@@ -357,6 +435,87 @@ func TestUpdateConversation(t *testing.T) {
 		resp, err := app.Test(req)
 		require.NoError(t, err)
 		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("handler success", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		userID := uuid.New()
+		conversationID := uuid.New()
+		title := "Updated Title"
+		body := models.UpdateConversationRequest{Title: &title}
+		jsonBody, _ := json.Marshal(body)
+
+		defaultModel := "default"
+		updatedConv := &models.AIConversation{
+			ID:        conversationID,
+			UserID:    userID,
+			Title:     "Updated Title",
+			ModelID:   &defaultModel,
+			UpdatedAt: time.Now(),
+		}
+		mockSvc.On("UpdateConversation", mock.Anything, userID, conversationID, mock.MatchedBy(func(req *models.UpdateConversationRequest) bool {
+			return req.Title != nil && *req.Title == "Updated Title"
+		})).Return(updatedConv, nil)
+
+		req := httptest.NewRequest("PATCH", "/api/v1/ai/conversations/"+conversationID.String(), bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Test-User-ID", userID.String())
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		respBody, _ := io.ReadAll(resp.Body)
+		var result models.AIConversation
+		err = json.Unmarshal(respBody, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Title", result.Title)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("handler unauthorized without user ID", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		conversationID := uuid.New()
+		title := "Updated Title"
+		body := models.UpdateConversationRequest{Title: &title}
+		jsonBody, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("PATCH", "/api/v1/ai/conversations/"+conversationID.String(), bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		// No X-Test-User-ID header
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("handler internal error", func(t *testing.T) {
+		mockSvc := new(MockChatService)
+		handler := NewAIChatHandler(mockSvc)
+		app := setupAIChatTestApp(t, handler)
+
+		userID := uuid.New()
+		conversationID := uuid.New()
+		title := "Updated Title"
+		body := models.UpdateConversationRequest{Title: &title}
+		jsonBody, _ := json.Marshal(body)
+
+		mockSvc.On("UpdateConversation", mock.Anything, userID, conversationID, mock.Anything).Return(nil, errors.New("database error"))
+
+		req := httptest.NewRequest("PATCH", "/api/v1/ai/conversations/"+conversationID.String(), bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Test-User-ID", userID.String())
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+		mockSvc.AssertExpectations(t)
 	})
 }
 

--- a/backend/internal/api/handlers/soundboard.go
+++ b/backend/internal/api/handlers/soundboard.go
@@ -8,16 +8,18 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
+	"hearth/internal/models"
 	"hearth/internal/services"
 )
 
 // validAudioExtensions contains the allowed audio file extensions
 var validAudioExtensions = map[string]bool{
-	".mp3": true,
-	".wav": true,
-	".ogg": true,
-	".m4a": true,
-	".aac": true,
+	".mp3":  true,
+	".wav":  true,
+	".ogg":  true,
+	".m4a":  true,
+	".aac":  true,
+	".opus": true,
 }
 
 // validateAudioURL validates that the given URL is a valid audio file URL
@@ -37,7 +39,7 @@ func validateAudioURL(audioURL string) error {
 
 	ext := filepath.Ext(parsed.Path)
 	if !validAudioExtensions[ext] {
-		return errors.New("audio URL must point to a valid audio file (.mp3, .wav, .ogg, .m4a, .aac)")
+		return errors.New("audio URL must point to a valid audio file (.mp3, .wav, .ogg, .m4a, .aac, .opus)")
 	}
 
 	return nil
@@ -65,7 +67,11 @@ func (h *SoundboardHandler) ListDefaultSounds(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to get default sounds"})
 	}
-	return c.JSON(sounds)
+	responses := make([]interface{}, 0, len(sounds))
+	for _, sound := range sounds {
+		responses = append(responses, sound.ToResponse())
+	}
+	return c.JSON(responses)
 }
 
 // ListServerSounds returns all soundboard sounds for a server
@@ -79,7 +85,11 @@ func (h *SoundboardHandler) ListServerSounds(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to get server sounds"})
 	}
-	return c.JSON(sounds)
+	responses := make([]interface{}, 0, len(sounds))
+	for _, sound := range sounds {
+		responses = append(responses, sound.ToResponse())
+	}
+	return c.JSON(responses)
 }
 
 // GetSound returns a single soundboard sound by ID
@@ -93,7 +103,7 @@ func (h *SoundboardHandler) GetSound(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "sound not found"})
 	}
-	return c.JSON(sound)
+	return c.JSON(sound.ToResponse())
 }
 
 // CreateSound creates a new soundboard sound for a server
@@ -123,17 +133,59 @@ func (h *SoundboardHandler) CreateSound(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid user authentication"})
 	}
 
-	sound, err := h.soundboardService.Create(c.Context(), &serverID, req.Name, req.EmojiName, req.Volume, nil, uploaderID)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to create sound"})
-	}
-	// Validate audio URL if provided
-	if req.AudioURL != "" {
+	// Handle file upload or URL-based creation
+	var sound *models.SoundboardSound
+	if audioFile := c.FormValue("audio"); audioFile != "" {
+		// File upload path
+		fileHeader, err := c.FormFile("audio")
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "audio file is required"})
+		}
+		name := req.Name
+		if name == "" {
+			name = c.FormValue("name")
+		}
+		emojiName := req.EmojiName
+		if emojiName == "" {
+			emojiName = c.FormValue("emoji_name")
+		}
+		volume := req.Volume
+		if volume <= 0 {
+			volume = 1.0
+		}
+		sound, err = h.soundboardService.Create(c.Context(), &serverID, name, emojiName, volume, fileHeader, uploaderID)
+		if err != nil {
+			if errors.Is(err, services.ErrSoundboardNameRequired) ||
+				errors.Is(err, services.ErrSoundboardNameTooLong) ||
+				errors.Is(err, services.ErrSoundboardFormat) ||
+				errors.Is(err, services.ErrSoundboardTooLarge) {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to create sound"})
+		}
+	} else {
+		// URL-based creation
+		if req.AudioURL == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "audio file or audio_url is required"})
+		}
 		if err := validateAudioURL(req.AudioURL); err != nil {
-			return err
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+		}
+		volume := req.Volume
+		if volume <= 0 {
+			volume = 1.0
+		}
+		sound, err = h.soundboardService.Create(c.Context(), &serverID, req.Name, req.EmojiName, volume, nil, uploaderID)
+		if err != nil {
+			if errors.Is(err, services.ErrSoundboardNameRequired) ||
+				errors.Is(err, services.ErrSoundboardNameTooLong) {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to create sound"})
 		}
 	}
-	return c.Status(fiber.StatusCreated).JSON(sound)
+
+	return c.Status(fiber.StatusCreated).JSON(sound.ToResponse())
 }
 
 // ModifySound updates a soundboard sound's properties
@@ -155,9 +207,12 @@ func (h *SoundboardHandler) ModifySound(c *fiber.Ctx) error {
 
 	sound, err := h.soundboardService.Update(c.Context(), soundID, req.Name, req.EmojiName, req.Volume, req.Available)
 	if err != nil {
+		if errors.Is(err, services.ErrSoundboardSoundNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "sound not found"})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to update sound"})
 	}
-	return c.JSON(sound)
+	return c.JSON(sound.ToResponse())
 }
 
 // DeleteSound deletes a soundboard sound
@@ -168,7 +223,167 @@ func (h *SoundboardHandler) DeleteSound(c *fiber.Ctx) error {
 	}
 
 	if err := h.soundboardService.Delete(c.Context(), soundID); err != nil {
+		if errors.Is(err, services.ErrSoundboardSoundNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "sound not found"})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to delete sound"})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// --- Pack endpoints ---
+
+// ListServerPacks returns all soundboard packs for a server
+func (h *SoundboardHandler) ListServerPacks(c *fiber.Ctx) error {
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid server ID"})
+	}
+
+	packs, err := h.soundboardService.GetPacksByServer(c.Context(), serverID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to get server packs"})
+	}
+
+	responses := make([]interface{}, 0, len(packs))
+	for _, pack := range packs {
+		responses = append(responses, pack.ToResponse())
+	}
+	return c.JSON(responses)
+}
+
+// GetPack returns a single soundboard pack by ID
+func (h *SoundboardHandler) GetPack(c *fiber.Ctx) error {
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid pack ID"})
+	}
+
+	pack, err := h.soundboardService.GetPack(c.Context(), packID)
+	if err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "pack not found"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to get pack"})
+	}
+	return c.JSON(pack.ToResponse())
+}
+
+// CreatePack creates a new soundboard pack for a server
+func (h *SoundboardHandler) CreatePack(c *fiber.Ctx) error {
+	serverID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid server ID"})
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		EmojiName string `json:"emoji_name"`
+		IsDefault bool   `json:"is_default"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+
+	pack, err := h.soundboardService.CreatePack(c.Context(), &serverID, req.Name, req.EmojiName, req.IsDefault)
+	if err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNameReq) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "pack name is required"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to create pack"})
+	}
+	return c.Status(fiber.StatusCreated).JSON(pack.ToResponse())
+}
+
+// ModifyPack updates a soundboard pack's properties
+func (h *SoundboardHandler) ModifyPack(c *fiber.Ctx) error {
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid pack ID"})
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		EmojiName string `json:"emoji_name"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+
+	pack, err := h.soundboardService.UpdatePack(c.Context(), packID, req.Name, req.EmojiName)
+	if err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "pack not found"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to update pack"})
+	}
+	return c.JSON(pack.ToResponse())
+}
+
+// DeletePack deletes a soundboard pack
+func (h *SoundboardHandler) DeletePack(c *fiber.Ctx) error {
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid pack ID"})
+	}
+
+	if err := h.soundboardService.DeletePack(c.Context(), packID); err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "pack not found"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to delete pack"})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// AddSoundToPack adds a sound to a pack
+func (h *SoundboardHandler) AddSoundToPack(c *fiber.Ctx) error {
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid pack ID"})
+	}
+
+	var req struct {
+		SoundID   string `json:"sound_id"`
+		Position  int    `json:"position"`
+		IsDefault bool   `json:"is_default"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+
+	soundID, err := uuid.Parse(req.SoundID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid sound ID"})
+	}
+
+	if err := h.soundboardService.AddSoundToPack(c.Context(), packID, soundID, req.Position, req.IsDefault); err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNotFound) ||
+			errors.Is(err, services.ErrSoundboardSoundNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to add sound to pack"})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// RemoveSoundFromPack removes a sound from a pack
+func (h *SoundboardHandler) RemoveSoundFromPack(c *fiber.Ctx) error {
+	packID, err := uuid.Parse(c.Params("packId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid pack ID"})
+	}
+
+	soundID, err := uuid.Parse(c.Params("soundId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid sound ID"})
+	}
+
+	if err := h.soundboardService.RemoveSoundFromPack(c.Context(), packID, soundID); err != nil {
+		if errors.Is(err, services.ErrSoundboardPackNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "pack not found"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to remove sound from pack"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/backend/internal/api/handlers/soundboard_test.go
+++ b/backend/internal/api/handlers/soundboard_test.go
@@ -342,7 +342,7 @@ func TestSoundboardHandler_DeleteSound_NotFound(t *testing.T) {
 	resp, err := app.Test(req, -1)
 
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
 // Test validateAudioURL function

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -539,6 +539,28 @@ func SetupRoutes(app *fiber.App, h *handlers.Handlers, m *middleware.Middleware)
 		servers.Delete("/:id/stickers/:stickerId", h.Stickers.DeleteSticker)
 	}
 
+	// Soundboard (if handler is configured)
+	if h.Soundboard != nil {
+		// Global soundboard sounds
+		api.Get("/soundboard/defaults", h.Soundboard.ListDefaultSounds)
+
+		// Server-specific soundboard sounds and packs
+		servers.Get("/:id/soundboard", h.Soundboard.ListServerSounds)
+		servers.Post("/:id/soundboard", h.Soundboard.CreateSound)
+		servers.Get("/:id/soundboard/sounds/:soundId", h.Soundboard.GetSound)
+		servers.Patch("/:id/soundboard/sounds/:soundId", h.Soundboard.ModifySound)
+		servers.Delete("/:id/soundboard/sounds/:soundId", h.Soundboard.DeleteSound)
+
+		// Soundboard packs
+		servers.Get("/:id/soundboard/packs", h.Soundboard.ListServerPacks)
+		servers.Post("/:id/soundboard/packs", h.Soundboard.CreatePack)
+		servers.Get("/:id/soundboard/packs/:packId", h.Soundboard.GetPack)
+		servers.Patch("/:id/soundboard/packs/:packId", h.Soundboard.ModifyPack)
+		servers.Delete("/:id/soundboard/packs/:packId", h.Soundboard.DeletePack)
+		servers.Put("/:id/soundboard/packs/:packId/sounds/:soundId", h.Soundboard.AddSoundToPack)
+		servers.Delete("/:id/soundboard/packs/:packId/sounds/:soundId", h.Soundboard.RemoveSoundFromPack)
+	}
+
 	// Server Templates (if handler is configured)
 	if h.Templates != nil {
 		// List public templates

--- a/backend/internal/models/link_preview.go
+++ b/backend/internal/models/link_preview.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LinkPreview represents cached OpenGraph/metadata for a URL
+type LinkPreview struct {
+	ID          uuid.UUID  `json:"id" db:"id"`
+	URL         string     `json:"url" db:"url"`
+	Title       *string    `json:"title,omitempty" db:"title"`
+	Description *string    `json:"description,omitempty" db:"description"`
+	ImageURL    *string    `json:"image_url,omitempty" db:"image_url"`
+	VideoURL    *string    `json:"video_url,omitempty" db:"video_url"`
+	SiteName    *string    `json:"site_name,omitempty" db:"site_name"`
+	Type        string     `json:"type" db:"type"` // website, video, image, rich, audio
+	Width       *int       `json:"width,omitempty" db:"width"`
+	Height      *int       `json:"height,omitempty" db:"height"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty" db:"expires_at"`
+	CreatedAt   time.Time  `json:"created_at" db:"created_at"`
+}
+
+// MessageLinkPreview associates a link preview with a message
+type MessageLinkPreview struct {
+	MessageID     uuid.UUID `json:"message_id" db:"message_id"`
+	LinkPreviewID uuid.UUID `json:"link_preview_id" db:"link_preview_id"`
+}
+
+// CreateLinkPreviewRequest is the input for creating a link preview
+type CreateLinkPreviewRequest struct {
+	URL string `json:"url" validate:"required,url"`
+}
+
+// LinkPreviewResponse is the API response for a link preview
+type LinkPreviewResponse struct {
+	ID          uuid.UUID  `json:"id"`
+	URL         string     `json:"url"`
+	Title       *string     `json:"title,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	ImageURL    *string     `json:"image_url,omitempty"`
+	VideoURL    *string     `json:"video_url,omitempty"`
+	SiteName    *string     `json:"site_name,omitempty"`
+	Type        string      `json:"type"`
+	Width       *int        `json:"width,omitempty"`
+	Height      *int        `json:"height,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+}
+
+// ToResponse converts a LinkPreview to its API response format
+func (lp *LinkPreview) ToResponse() *LinkPreviewResponse {
+	return &LinkPreviewResponse{
+		ID:          lp.ID,
+		URL:         lp.URL,
+		Title:       lp.Title,
+		Description: lp.Description,
+		ImageURL:    lp.ImageURL,
+		VideoURL:    lp.VideoURL,
+		SiteName:    lp.SiteName,
+		Type:        lp.Type,
+		Width:       lp.Width,
+		Height:      lp.Height,
+		ExpiresAt:   lp.ExpiresAt,
+	}
+}

--- a/backend/internal/models/soundboard.go
+++ b/backend/internal/models/soundboard.go
@@ -81,3 +81,63 @@ type SoundboardPlayEvent struct {
 	ChannelID  string  `json:"channel_id"`
 	ServerID   string  `json:"server_id"`
 }
+
+// SoundboardSoundPack represents a collection of soundboard sounds
+type SoundboardSoundPack struct {
+	ID        uuid.UUID          `json:"id" db:"id"`
+	ServerID  *uuid.UUID         `json:"server_id,omitempty" db:"server_id"`
+	Name      string             `json:"name" db:"name"`
+	EmojiName string             `json:"emoji_name,omitempty" db:"emoji_name"`
+	Sounds    []*SoundboardSound `json:"sounds,omitempty" db:"-"`
+	IsDefault bool               `json:"is_default" db:"is_default"`
+	Position  int                `json:"position" db:"position"`
+	CreatedAt time.Time          `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at" db:"updated_at"`
+}
+
+// SoundboardSoundPackResponse is the API response for a soundboard pack
+type SoundboardSoundPackResponse struct {
+	ID        string                      `json:"id"`
+	ServerID  *string                     `json:"guild_id,omitempty"`
+	Name      string                      `json:"name"`
+	EmojiName string                      `json:"emoji_name,omitempty"`
+	Sounds    []SoundboardSoundResponse   `json:"sounds"`
+	IsDefault bool                        `json:"is_default"`
+	Position  int                         `json:"position"`
+	CreatedAt string                      `json:"created_at"`
+	UpdatedAt string                      `json:"updated_at"`
+}
+
+// ToResponse converts a SoundboardSoundPack to SoundboardSoundPackResponse
+func (p *SoundboardSoundPack) ToResponse() SoundboardSoundPackResponse {
+	resp := SoundboardSoundPackResponse{
+		ID:        p.ID.String(),
+		Name:      p.Name,
+		EmojiName: p.EmojiName,
+		IsDefault: p.IsDefault,
+		Position:  p.Position,
+		CreatedAt: p.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
+		Sounds:    make([]SoundboardSoundResponse, 0, len(p.Sounds)),
+	}
+	if p.ServerID != nil {
+		serverIDStr := p.ServerID.String()
+		resp.ServerID = &serverIDStr
+	}
+	for _, sound := range p.Sounds {
+		resp.Sounds = append(resp.Sounds, sound.ToResponse())
+	}
+	return resp
+}
+
+// SoundboardPlayingSound represents a sound currently being played
+type SoundboardPlayingSound struct {
+	SoundID    uuid.UUID `json:"sound_id"`
+	SoundName  string    `json:"sound_name"`
+	EmojiName  string    `json:"emoji_name,omitempty"`
+	AudioURL   string    `json:"audio_url"`
+	Volume     float64   `json:"volume"`
+	DurationMs int       `json:"duration_ms"`
+	StartedAt  time.Time `json:"started_at"`
+	PlayedBy   uuid.UUID `json:"played_by"`
+}

--- a/backend/internal/services/link_preview_service.go
+++ b/backend/internal/services/link_preview_service.go
@@ -1,0 +1,267 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"hearth/internal/models"
+)
+
+var (
+	ErrLinkPreviewNotFound = errors.New("link preview not found")
+	ErrInvalidURL         = errors.New("invalid URL")
+	ErrUnreachableURL     = errors.New("URL is unreachable")
+
+	defaultPreviewTTL = 24 * time.Hour
+)
+
+// LinkPreviewService extracts and caches OpenGraph metadata for URLs
+type LinkPreviewService struct {
+	mu          sync.RWMutex
+	cache       map[string]*cachedPreview
+	httpClient  *http.Client
+	maxBodySize int64 // max bytes to read when fetching
+}
+
+type cachedPreview struct {
+	preview *models.LinkPreview
+	expiry  time.Time
+}
+
+// NewLinkPreviewService creates a new link preview service
+func NewLinkPreviewService() *LinkPreviewService {
+	return &LinkPreviewService{
+		cache: make(map[string]*cachedPreview),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return errors.New("too many redirects")
+				}
+				return nil
+			},
+		},
+		maxBodySize: 5 * 1024 * 1024, // 5MB
+	}
+}
+
+// GetPreview fetches or retrieves from cache a link preview for a URL
+func (s *LinkPreviewService) GetPreview(ctx context.Context, rawURL string) (*models.LinkPreview, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, ErrInvalidURL
+	}
+
+	// Check cache
+	cacheKey := parsedURL.String()
+	s.mu.RLock()
+	if cached, ok := s.cache[cacheKey]; ok && time.Now().Before(cached.expiry) {
+		s.mu.RUnlock()
+		return cached.preview, nil
+	}
+	s.mu.RUnlock()
+
+	// Fetch and extract
+	preview, err := s.extractPreview(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache it
+	s.mu.Lock()
+	s.cache[cacheKey] = &cachedPreview{
+		preview: preview,
+		expiry:  time.Now().Add(defaultPreviewTTL),
+	}
+	s.mu.Unlock()
+
+	return preview, nil
+}
+
+// extractPreview fetches a URL and extracts OpenGraph metadata
+func (s *LinkPreviewService) extractPreview(ctx context.Context, rawURL string) (*models.LinkPreview, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, ErrInvalidURL
+	}
+	req.Header.Set("User-Agent", "HearthLinkPreview/1.0 (+https://hearth.chat)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, ErrUnreachableURL
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, ErrUnreachableURL
+	}
+
+	// Limit body read
+	limited := io.LimitReader(resp.Body, s.maxBodySize)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, ErrUnreachableURL
+	}
+
+	preview := &models.LinkPreview{
+		ID:        uuid.New(),
+		URL:       rawURL,
+		Type:      "website",
+		CreatedAt: time.Now(),
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "video") {
+		preview.Type = "video"
+	} else if strings.Contains(contentType, "audio") {
+		preview.Type = "audio"
+	} else if strings.Contains(contentType, "image") {
+		preview.Type = "image"
+	}
+
+	// Extract OpenGraph tags
+	s.extractOGTags(string(body), preview)
+
+	// Set expiry
+	ttl := defaultPreviewTTL
+	exp := time.Now().Add(ttl)
+	preview.ExpiresAt = &exp
+
+	return preview, nil
+}
+
+var ogTagRegex = regexp.MustCompile(`<meta[^>]+(?:property|name)=["'](?:og:)?([^"']+)["'][^>]+content=["']([^"']+)["']`)
+var ogTagRegex2 = regexp.MustCompile(`<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["'](?:og:)?([^"']+)["']`)
+
+func (s *LinkPreviewService) extractOGTags(htmlContent string, preview *models.LinkPreview) {
+	// Extract og: tags first (they take precedence)
+	for _, re := range []*regexp.Regexp{ogTagRegex, ogTagRegex2} {
+		matches := re.FindAllStringSubmatch(htmlContent, -1)
+		for _, match := range matches {
+			var key, value string
+			if re == ogTagRegex {
+				key, value = match[1], match[2]
+			} else {
+				value, key = match[1], match[2]
+			}
+			value = decodeHTMLEntities(strings.TrimSpace(value))
+
+			switch key {
+			case "title", "og:title":
+				if preview.Title == nil || *preview.Title == "" {
+					preview.Title = &value
+				}
+			case "description", "og:description":
+				preview.Description = &value
+			case "image", "og:image":
+				preview.ImageURL = &value
+			case "video", "og:video":
+				preview.VideoURL = &value
+			case "site_name", "og:site_name":
+				preview.SiteName = &value
+			case "type", "og:type":
+				preview.Type = value
+			case "width", "og:width":
+				if w := parseInt(value); w > 0 {
+					preview.Width = &w
+				}
+			case "height", "og:height":
+				if h := parseInt(value); h > 0 {
+					preview.Height = &h
+				}
+			}
+		}
+	}
+
+	// Fallback to <title> tag if og:title wasn't set
+	if preview.Title == nil {
+		if titleMatch := regexp.MustCompile(`<title[^>]*>([^<]+)</title>`).FindStringSubmatch(htmlContent); len(titleMatch) > 1 {
+			title := decodeHTMLEntities(strings.TrimSpace(titleMatch[1]))
+			preview.Title = &title
+		}
+	}
+}
+
+func decodeHTMLEntities(s string) string {
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&#39;", "'")
+	s = strings.ReplaceAll(s, "&apos;", "'")
+	// Decode numeric entities
+	s = decodeNumEntity(s, `&#(\d+);`)
+	s = decodeNumEntity(s, `&#x([0-9a-fA-F]+);`)
+	return s
+}
+
+func decodeNumEntity(s, pattern string) string {
+	re := regexp.MustCompile(pattern)
+	return re.ReplaceAllStringFunc(s, func(match string) string {
+		var num int
+		if strings.HasPrefix(match, "&#x") {
+			hex := match[3 : len(match)-1]
+			fmt.Sscanf(hex, "%x", &num)
+		} else {
+			fmt.Sscanf(match[2:len(match)-1], "%d", &num)
+		}
+		if num > 0 && num < 0x10FFFF {
+			return string(rune(num))
+		}
+		return match
+	})
+}
+
+func parseInt(s string) int {
+	var n int
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// ClearCache invalidates all cached previews
+func (s *LinkPreviewService) ClearCache() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache = make(map[string]*cachedPreview)
+}
+
+// InvalidateURL removes a specific URL from the cache
+func (s *LinkPreviewService) InvalidateURL(rawURL string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.cache, rawURL)
+}
+
+// PurgeExpired removes expired entries from cache
+func (s *LinkPreviewService) PurgeExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, v := range s.cache {
+		if now.After(v.expiry) {
+			delete(s.cache, k)
+		}
+	}
+}
+
+// IsEmptyBody checks if reader has no content (for tests)
+func IsEmptyBody(body []byte) bool {
+	return len(bytes.TrimSpace(body)) == 0
+}

--- a/backend/internal/services/link_preview_service_test.go
+++ b/backend/internal/services/link_preview_service_test.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"hearth/internal/models"
+)
+
+func TestLinkPreviewService_InvalidURL(t *testing.T) {
+	svc := NewLinkPreviewService()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"empty string", ""},
+		{"no scheme", "example.com"},
+		{"just path", "/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.GetPreview(ctx, tt.url)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", tt.url)
+			}
+		})
+	}
+}
+
+func TestLinkPreviewService_CacheHit(t *testing.T) {
+	svc := NewLinkPreviewService()
+	ctx := context.Background()
+
+	// Create a test server that returns consistent OG tags
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+<title>Test Site</title>
+<meta property="og:title" content="OG Title">
+<meta property="og:description" content="OG Description">
+<meta property="og:image" content="https://example.com/image.png">
+<meta property="og:type" content="website">
+</head>
+<body></body>
+</html>`))
+	}))
+	defer server.Close()
+
+	// First call should hit the server
+	preview1, err := svc.GetPreview(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	if preview1.Title == nil || *preview1.Title != "OG Title" {
+		t.Errorf("expected title 'OG Title', got %v", preview1.Title)
+	}
+
+	// Second call should use cache (same preview ID)
+	preview2, err := svc.GetPreview(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	if preview1.ID != preview2.ID {
+		t.Errorf("expected same preview ID from cache, got different")
+	}
+}
+
+func TestLinkPreviewService_ExtractOGTags(t *testing.T) {
+	svc := NewLinkPreviewService()
+
+	tests := []struct {
+		name     string
+		html     string
+		checkFn  func(*testing.T, *testPreview)
+	}{
+		{
+			name: "basic og tags",
+			html: `<!DOCTYPE html><html><head>
+<meta property="og:title" content="Test Title">
+<meta property="og:description" content="Test Description">
+<meta property="og:image" content="https://img.example.com/test.png">
+<meta property="og:type" content="article">
+</head></html>`,
+			checkFn: func(t *testing.T, p *testPreview) {
+				if p.Title == nil || *p.Title != "Test Title" {
+					t.Errorf("expected title 'Test Title', got %v", p.Title)
+				}
+				if p.Description == nil || *p.Description != "Test Description" {
+					t.Errorf("expected description 'Test Description', got %v", p.Description)
+				}
+				if p.Type != "article" {
+					t.Errorf("expected type 'article', got %s", p.Type)
+				}
+			},
+		},
+		{
+			name: "html entities decoded",
+			html: `<!DOCTYPE html><html><head><title>Tom &amp; Jerry</title></head></html>`,
+			checkFn: func(t *testing.T, p *testPreview) {
+				if p.Title == nil || *p.Title != "Tom & Jerry" {
+					t.Errorf("expected title 'Tom & Jerry', got %v", p.Title)
+				}
+			},
+		},
+		{
+			name: "no og tags falls back to title tag",
+			html: `<!DOCTYPE html><html><head><title>Fallback Title</title></head></html>`,
+			checkFn: func(t *testing.T, p *testPreview) {
+				if p.Title == nil || *p.Title != "Fallback Title" {
+					t.Errorf("expected title 'Fallback Title', got %v", p.Title)
+				}
+			},
+		},
+		{
+			name: "video content type",
+			html: `<!DOCTYPE html><html><head></head></html>`,
+			checkFn: func(t *testing.T, p *testPreview) {
+				// default type should be website
+				if p.Type != "website" {
+					t.Errorf("expected default type 'website', got %s", p.Type)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.Write([]byte(tt.html))
+			}))
+			defer server.Close()
+
+			preview, err := svc.extractPreview(context.Background(), server.URL)
+			if err != nil {
+				t.Fatalf("extractPreview failed: %v", err)
+			}
+
+			tt.checkFn(t, &testPreview{
+				Title:       preview.Title,
+				Description: preview.Description,
+				ImageURL:    preview.ImageURL,
+				Type:        preview.Type,
+			})
+		})
+	}
+}
+
+type testPreview struct {
+	Title       *string
+	Description *string
+	ImageURL    *string
+	Type        string
+}
+
+func TestLinkPreviewService_ClearCache(t *testing.T) {
+	svc := NewLinkPreviewService()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head><title>Test</title></head></html>`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	preview1, _ := svc.GetPreview(ctx, server.URL)
+	id1 := preview1.ID
+
+	// Modify the server to return different content
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head><title>Different</title></head></html>`))
+	})
+
+	// Without clear, should still get cached version
+	preview2, _ := svc.GetPreview(ctx, server.URL)
+	if preview1.ID != preview2.ID {
+		t.Errorf("expected cache hit, got different ID")
+	}
+
+	// Clear cache
+	svc.ClearCache()
+
+	// After clear, should get new version
+	preview3, _ := svc.GetPreview(ctx, server.URL)
+	if id1 == preview3.ID {
+		t.Errorf("expected new preview after cache clear, got same ID")
+	}
+}
+
+func TestLinkPreviewService_PurgeExpired(t *testing.T) {
+	svc := NewLinkPreviewService()
+	// Manually add an expired entry
+	svc.mu.Lock()
+	svc.cache["http://expired.example.com"] = &cachedPreview{
+		preview: &models.LinkPreview{ID: uuid.New()},
+		expiry:  time.Now().Add(-1 * time.Hour),
+	}
+	svc.mu.Unlock()
+
+	svc.PurgeExpired()
+
+	svc.mu.RLock()
+	if _, ok := svc.cache["http://expired.example.com"]; ok {
+		t.Errorf("expected expired entry to be purged")
+	}
+	svc.mu.RUnlock()
+}

--- a/backend/internal/services/soundboard_service.go
+++ b/backend/internal/services/soundboard_service.go
@@ -24,12 +24,15 @@ var (
 	ErrSoundboardTooLarge      = errors.New("sound file too large (max 5 seconds / 500KB)")
 	ErrSoundboardFormat        = errors.New("invalid sound format (only MP3, OGG, WAV, OPUS allowed)")
 	ErrSoundboardDuration      = errors.New("sound duration too long (max 5000ms)")
+	ErrSoundboardPackNotFound  = errors.New("soundboard pack not found")
+	ErrSoundboardPackNameReq   = errors.New("pack name is required")
 )
 
 // SoundboardService handles soundboard business logic
 type SoundboardService struct {
 	mu      sync.RWMutex
 	sounds  map[uuid.UUID]*models.SoundboardSound
+	packs   map[uuid.UUID]*models.SoundboardSoundPack
 	storage *storage.Service
 }
 
@@ -37,6 +40,7 @@ type SoundboardService struct {
 func NewSoundboardService(storageService *storage.Service) *SoundboardService {
 	return &SoundboardService{
 		sounds:  make(map[uuid.UUID]*models.SoundboardSound),
+		packs:   make(map[uuid.UUID]*models.SoundboardSoundPack),
 		storage: storageService,
 	}
 }
@@ -286,6 +290,162 @@ func (s *SoundboardService) Search(ctx context.Context, query string, serverID *
 	}
 
 	return sounds, nil
+}
+
+// --- Pack methods ---
+
+// CreatePack creates a new soundboard pack
+func (s *SoundboardService) CreatePack(ctx context.Context, serverID *uuid.UUID, name string, emojiName string, isDefault bool) (*models.SoundboardSoundPack, error) {
+	if name == "" {
+		return nil, ErrSoundboardPackNameReq
+	}
+	if len(name) > 100 {
+		return nil, ErrSoundboardNameTooLong
+	}
+
+	pack := &models.SoundboardSoundPack{
+		ID:        uuid.New(),
+		ServerID:  serverID,
+		Name:      name,
+		EmojiName: emojiName,
+		IsDefault: isDefault,
+		Position:  0,
+		Sounds:    []*models.SoundboardSound{},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	s.mu.Lock()
+	s.packs[pack.ID] = pack
+	s.mu.Unlock()
+
+	return pack, nil
+}
+
+// GetPack retrieves a pack by ID
+func (s *SoundboardService) GetPack(ctx context.Context, packID uuid.UUID) (*models.SoundboardSoundPack, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pack, ok := s.packs[packID]
+	if !ok {
+		return nil, ErrSoundboardPackNotFound
+	}
+	return pack, nil
+}
+
+// GetPacksByServer retrieves all packs for a server
+func (s *SoundboardService) GetPacksByServer(ctx context.Context, serverID uuid.UUID) ([]*models.SoundboardSoundPack, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var packs []*models.SoundboardSoundPack
+	for _, pack := range s.packs {
+		if pack.ServerID != nil && *pack.ServerID == serverID {
+			packs = append(packs, pack)
+		}
+	}
+	return packs, nil
+}
+
+// GetDefaultPacks retrieves all default/global packs
+func (s *SoundboardService) GetDefaultPacks(ctx context.Context) ([]*models.SoundboardSoundPack, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var packs []*models.SoundboardSoundPack
+	for _, pack := range s.packs {
+		if pack.ServerID == nil {
+			packs = append(packs, pack)
+		}
+	}
+	return packs, nil
+}
+
+// UpdatePack updates a pack's properties
+func (s *SoundboardService) UpdatePack(ctx context.Context, packID uuid.UUID, name string, emojiName string) (*models.SoundboardSoundPack, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pack, ok := s.packs[packID]
+	if !ok {
+		return nil, ErrSoundboardPackNotFound
+	}
+
+	if name != "" {
+		if len(name) > 100 {
+			return nil, ErrSoundboardNameTooLong
+		}
+		pack.Name = name
+	}
+	if emojiName != "" {
+		pack.EmojiName = emojiName
+	}
+	pack.UpdatedAt = time.Now()
+
+	return pack, nil
+}
+
+// DeletePack deletes a pack
+func (s *SoundboardService) DeletePack(ctx context.Context, packID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.packs[packID]; !ok {
+		return ErrSoundboardPackNotFound
+	}
+
+	delete(s.packs, packID)
+	return nil
+}
+
+// AddSoundToPack adds a sound to a pack
+func (s *SoundboardService) AddSoundToPack(ctx context.Context, packID, soundID uuid.UUID, position int, isDefault bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pack, ok := s.packs[packID]
+	if !ok {
+		return ErrSoundboardPackNotFound
+	}
+	sound, ok := s.sounds[soundID]
+	if !ok {
+		return ErrSoundboardSoundNotFound
+	}
+	_ = position
+	_ = isDefault
+	pack.Sounds = append(pack.Sounds, sound)
+	return nil
+}
+
+// RemoveSoundFromPack removes a sound from a pack
+func (s *SoundboardService) RemoveSoundFromPack(ctx context.Context, packID, soundID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pack, ok := s.packs[packID]
+	if !ok {
+		return ErrSoundboardPackNotFound
+	}
+	for i, sound := range pack.Sounds {
+		if sound.ID == soundID {
+			pack.Sounds = append(pack.Sounds[:i], pack.Sounds[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// GetSoundsInPack retrieves all sounds in a pack
+func (s *SoundboardService) GetSoundsInPack(ctx context.Context, packID uuid.UUID) ([]*models.SoundboardSound, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pack, ok := s.packs[packID]
+	if !ok {
+		return nil, ErrSoundboardPackNotFound
+	}
+	return pack.Sounds, nil
 }
 
 // Add_Test is a test helper to add a sound directly

--- a/backend/internal/websocket/gateway.go
+++ b/backend/internal/websocket/gateway.go
@@ -42,6 +42,9 @@ type Gateway struct {
 	// Voice signaling
 	voiceService *VoiceSignalingService
 
+	// Soundboard signaling
+	soundboardService *SoundboardSignalingService
+
 	// Session management
 	sessions   map[string]*Session
 	sessionsMu sync.RWMutex
@@ -416,6 +419,9 @@ func (g *Gateway) handleClientDispatch(conn *websocket.Conn, client *Client, ses
 	// Voice signaling events
 	case VoiceSignalJoin, VoiceSignalLeave, VoiceSignalOffer, VoiceSignalAnswer, VoiceSignalICECandidate, VoiceSignalSpeaking:
 		g.handleVoiceDispatch(conn, client, session, dispatchData.T, dispatchData.D)
+	// Soundboard events
+	case SoundboardSignalPlay, SoundboardSignalStop:
+		g.handleSoundboardDispatch(conn, client, session, dispatchData.T, dispatchData.D)
 	default:
 		log.Printf("[Gateway] Unknown client dispatch type: %s", dispatchData.T)
 	}
@@ -431,6 +437,19 @@ func (g *Gateway) handleVoiceDispatch(conn *websocket.Conn, client *Client, sess
 	if err := g.voiceService.HandleVoiceMessage(ctx, client, session.ID, eventType, data); err != nil {
 		log.Printf("[Gateway] Voice dispatch error: %v", err)
 		g.sendError(conn, "voice operation failed")
+	}
+}
+
+func (g *Gateway) handleSoundboardDispatch(conn *websocket.Conn, client *Client, session *Session, eventType string, data json.RawMessage) {
+	if g.soundboardService == nil {
+		g.sendError(conn, "soundboard not available")
+		return
+	}
+
+	ctx := context.Background()
+	if err := g.soundboardService.HandleSoundboardMessage(ctx, client, session.ID, eventType, data); err != nil {
+		log.Printf("[Gateway] Soundboard dispatch error: %v", err)
+		g.sendError(conn, "soundboard operation failed")
 	}
 }
 
@@ -873,6 +892,11 @@ func (g *Gateway) GetActiveConnections() int64 {
 // SetVoiceService sets the voice signaling service
 func (g *Gateway) SetVoiceService(vs *VoiceSignalingService) {
 	g.voiceService = vs
+}
+
+// SetSoundboardService sets the soundboard signaling service
+func (g *Gateway) SetSoundboardService(ss *SoundboardSignalingService) {
+	g.soundboardService = ss
 }
 
 // CleanupSession cleans up voice state when a session disconnects

--- a/backend/internal/websocket/message.go
+++ b/backend/internal/websocket/message.go
@@ -114,6 +114,10 @@ const (
 	EventServerFolderDelete   = "SERVER_FOLDER_DELETE"
 	EventServerFolderMove     = "SERVER_FOLDER_MOVE"
 	EventServerFolderReorder  = "SERVER_FOLDER_REORDER"
+
+	// Soundboard events
+	EventSoundboardPlay = "SOUNDBOARD_PLAY"
+	EventSoundboardStop = "SOUNDBOARD_STOP"
 )
 
 // DispatchEvent creates a dispatch message

--- a/backend/internal/websocket/soundboard.go
+++ b/backend/internal/websocket/soundboard.go
@@ -1,0 +1,211 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"hearth/internal/models"
+)
+
+// Soundboard signaling message types (client → server)
+const (
+	SoundboardSignalPlay  = "SOUNDBOARD_PLAY"
+	SoundboardSignalStop = "SOUNDBOARD_STOP"
+)
+
+// SoundboardSoundData represents data for playing a sound
+type SoundboardSoundData struct {
+	SoundID   uuid.UUID `json:"sound_id"`
+	ChannelID uuid.UUID `json:"channel_id"`
+	ServerID  uuid.UUID `json:"server_id"`
+	Volume    float64   `json:"volume,omitempty"`
+}
+
+// SoundboardStopData represents data for stopping a sound
+type SoundboardStopData struct {
+	SoundID   uuid.UUID `json:"sound_id"`
+	ChannelID uuid.UUID `json:"channel_id"`
+	ServerID  uuid.UUID `json:"server_id"`
+}
+
+// SoundboardSignalingService handles soundboard signaling within voice channels
+type SoundboardSignalingService struct {
+	hub HubInterface
+
+	// SoundboardService for looking up sound details
+	soundboardService interface {
+		Get(ctx context.Context, soundID uuid.UUID) (*models.SoundboardSound, error)
+	}
+
+	// Track which sounds are currently playing in which channels
+	// channelID -> soundID -> playingInfo
+	activeSounds   map[uuid.UUID]map[uuid.UUID]*models.SoundboardPlayingSound
+	activeSoundsMu sync.RWMutex
+}
+
+// NewSoundboardSignalingService creates a new soundboard signaling service
+func NewSoundboardSignalingService(hub HubInterface, soundboardService interface {
+	Get(ctx context.Context, soundID uuid.UUID) (*models.SoundboardSound, error)
+}) *SoundboardSignalingService {
+	return &SoundboardSignalingService{
+		hub:              hub,
+		soundboardService: soundboardService,
+		activeSounds:     make(map[uuid.UUID]map[uuid.UUID]*models.SoundboardPlayingSound),
+	}
+}
+
+// HandleSoundboardMessage handles incoming soundboard-related messages
+func (s *SoundboardSignalingService) HandleSoundboardMessage(ctx context.Context, client *Client, sessionID string, msgType string, data json.RawMessage) error {
+	switch msgType {
+	case SoundboardSignalPlay:
+		return s.handlePlay(ctx, client, data)
+	case SoundboardSignalStop:
+		return s.handleStop(ctx, client, data)
+	default:
+		log.Printf("[Soundboard] Unknown message type: %s", msgType)
+		return nil
+	}
+}
+
+// handlePlay handles a user playing a sound in a voice channel
+func (s *SoundboardSignalingService) handlePlay(ctx context.Context, client *Client, data json.RawMessage) error {
+	var playData SoundboardSoundData
+	if err := json.Unmarshal(data, &playData); err != nil {
+		return err
+	}
+
+	log.Printf("[Soundboard] User %s playing sound %s in channel %s", client.UserID, playData.SoundID, playData.ChannelID)
+
+	// Get sound details
+	sound, err := s.soundboardService.Get(ctx, playData.SoundID)
+	if err != nil {
+		log.Printf("[Soundboard] Sound not found: %s", playData.SoundID)
+		return nil // Silently fail - don't expose not found to client
+	}
+
+	if !sound.Available {
+		log.Printf("[Soundboard] Sound not available: %s", playData.SoundID)
+		return nil
+	}
+
+	// Use provided volume or sound's default
+	volume := playData.Volume
+	if volume <= 0 {
+		volume = sound.Volume
+	}
+
+	playingSound := &models.SoundboardPlayingSound{
+		SoundID:    sound.ID,
+		SoundName:  sound.Name,
+		EmojiName:  sound.EmojiName,
+		AudioURL:   sound.AudioURL,
+		Volume:     volume,
+		DurationMs: sound.DurationMs,
+		StartedAt:  time.Now(),
+		PlayedBy:   client.UserID,
+	}
+
+	// Track active sound
+	s.activeSoundsMu.Lock()
+	if s.activeSounds[playData.ChannelID] == nil {
+		s.activeSounds[playData.ChannelID] = make(map[uuid.UUID]*models.SoundboardPlayingSound)
+	}
+	s.activeSounds[playData.ChannelID][playData.SoundID] = playingSound
+	s.activeSoundsMu.Unlock()
+
+	// Auto-cleanup after duration
+	go func() {
+		time.Sleep(time.Duration(sound.DurationMs) * time.Millisecond)
+		s.activeSoundsMu.Lock()
+		if channelSounds, ok := s.activeSounds[playData.ChannelID]; ok {
+			delete(channelSounds, playData.SoundID)
+			if len(channelSounds) == 0 {
+				delete(s.activeSounds, playData.ChannelID)
+			}
+		}
+		s.activeSoundsMu.Unlock()
+	}()
+
+	// Broadcast play event to all users in the server
+	playEvent := models.SoundboardPlayEvent{
+		SoundID:    sound.ID.String(),
+		SoundName:  sound.Name,
+		EmojiName:  sound.EmojiName,
+		AudioURL:   sound.AudioURL,
+		Volume:     volume,
+		DurationMs: sound.DurationMs,
+		UserID:     client.UserID.String(),
+		ChannelID:  playData.ChannelID.String(),
+		ServerID:   playData.ServerID.String(),
+	}
+
+	s.hub.SendToServer(playData.ServerID, &Event{
+		Op:   OpDispatch,
+		Type: EventSoundboardPlay,
+		Data: playEvent,
+	})
+
+	return nil
+}
+
+// handleStop handles a user stopping a sound in a voice channel
+func (s *SoundboardSignalingService) handleStop(ctx context.Context, client *Client, data json.RawMessage) error {
+	var stopData SoundboardStopData
+	if err := json.Unmarshal(data, &stopData); err != nil {
+		return err
+	}
+
+	log.Printf("[Soundboard] User %s stopping sound %s in channel %s", client.UserID, stopData.SoundID, stopData.ChannelID)
+
+	// Remove from active sounds
+	s.activeSoundsMu.Lock()
+	if channelSounds, ok := s.activeSounds[stopData.ChannelID]; ok {
+		if sound, ok := channelSounds[stopData.SoundID]; ok {
+			// Only the user who started it can stop it
+			if sound.PlayedBy != client.UserID {
+				s.activeSoundsMu.Unlock()
+				return nil
+			}
+			delete(channelSounds, stopData.SoundID)
+			if len(channelSounds) == 0 {
+				delete(s.activeSounds, stopData.ChannelID)
+			}
+		}
+	}
+	s.activeSoundsMu.Unlock()
+
+	// Broadcast stop event to all users in the server
+	stopEvent := map[string]interface{}{
+		"sound_id":   stopData.SoundID.String(),
+		"channel_id": stopData.ChannelID.String(),
+		"server_id":  stopData.ServerID.String(),
+		"user_id":    client.UserID.String(),
+	}
+
+	s.hub.SendToServer(stopData.ServerID, &Event{
+		Op:   OpDispatch,
+		Type: EventSoundboardStop,
+		Data: stopEvent,
+	})
+
+	return nil
+}
+
+// GetActiveSounds returns all sounds currently playing in a channel
+func (s *SoundboardSignalingService) GetActiveSounds(ctx context.Context, channelID uuid.UUID) []*models.SoundboardPlayingSound {
+	s.activeSoundsMu.RLock()
+	defer s.activeSoundsMu.RUnlock()
+
+	var sounds []*models.SoundboardPlayingSound
+	if channelSounds, ok := s.activeSounds[channelID]; ok {
+		for _, sound := range channelSounds {
+			sounds = append(sounds, sound)
+		}
+	}
+	return sounds
+}

--- a/frontend/src/lib/api/soundboard.ts
+++ b/frontend/src/lib/api/soundboard.ts
@@ -1,0 +1,229 @@
+import { writable, get } from 'svelte/store';
+import { api } from '$lib/api';
+import { gateway, onGatewayEvent } from '$lib/stores/gateway';
+
+export interface SoundboardSound {
+	id: string;
+	name: string;
+	emoji_name?: string;
+	volume: number;
+	audio_url: string;
+	duration_ms: number;
+	available: boolean;
+	creator_id: string;
+	created_at: string;
+	guild_id?: string;
+}
+
+export interface SoundboardSoundPack {
+	id: string;
+	guild_id?: string;
+	name: string;
+	emoji_name?: string;
+	sounds: SoundboardSound[];
+	is_default: boolean;
+	position: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface SoundboardPlayEvent {
+	sound_id: string;
+	sound_name: string;
+	emoji_name?: string;
+	audio_url: string;
+	volume: number;
+	duration_ms: number;
+	user_id: string;
+	channel_id: string;
+	server_id: string;
+}
+
+// Soundboard API functions
+export async function fetchServerSounds(serverId: string): Promise<SoundboardSound[]> {
+	const response = await api.get<SoundboardSound[]>(`/servers/${serverId}/soundboard`);
+	return response || [];
+}
+
+export async function fetchDefaultSounds(): Promise<SoundboardSound[]> {
+	const response = await api.get<SoundboardSound[]>('/soundboard/defaults');
+	return response || [];
+}
+
+export async function fetchServerPacks(serverId: string): Promise<SoundboardSoundPack[]> {
+	const response = await api.get<SoundboardSoundPack[]>(`/servers/${serverId}/soundboard/packs`);
+	return response || [];
+}
+
+export async function createSound(serverId: string, data: {
+	name: string;
+	emoji_name?: string;
+	volume?: number;
+	audio_url?: string;
+}): Promise<SoundboardSound> {
+	return api.post<SoundboardSound>(`/servers/${serverId}/soundboard`, data);
+}
+
+export async function createPack(serverId: string, data: {
+	name: string;
+	emoji_name?: string;
+	is_default?: boolean;
+}): Promise<SoundboardSoundPack> {
+	return api.post<SoundboardSoundPack>(`/servers/${serverId}/soundboard/packs`, data);
+}
+
+// Soundboard WebSocket signaling
+export function sendSoundboardPlay(channelId: string, serverId: string, soundId: string, volume?: number): void {
+	gateway.send({
+		op: 0, // Dispatch
+		d: {
+			t: 'SOUNDBOARD_PLAY',
+			d: {
+				sound_id: soundId,
+				channel_id: channelId,
+				server_id: serverId,
+				volume: volume ?? 1.0,
+			},
+		},
+	});
+}
+
+export function sendSoundboardStop(channelId: string, serverId: string, soundId: string): void {
+	gateway.send({
+		op: 0, // Dispatch
+		d: {
+			t: 'SOUNDBOARD_STOP',
+			d: {
+				sound_id: soundId,
+				channel_id: channelId,
+				server_id: serverId,
+			},
+		},
+	});
+}
+
+// Soundboard hotkey store
+export interface HotkeyMapping {
+	soundId: string;
+	soundName: string;
+	emojiName?: string;
+	audioUrl: string;
+	volume: number;
+	durationMs: number;
+}
+
+export const soundboardHotkeys = writable<Map<number, HotkeyMapping>>(new Map());
+
+// F1-F9 key codes
+const HOTKEY_KEYS = [
+	'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9'
+];
+
+let currentHotkeyCleanup: (() => void) | null = null;
+
+export function setupSoundboardHotkeys(
+	sounds: SoundboardSound[],
+	channelId: string,
+	serverId: string,
+	onPlay?: (sound: SoundboardSound) => void
+): () => void {
+	// Clear previous hotkeys
+	if (currentHotkeyCleanup) {
+		currentHotkeyCleanup();
+		currentHotkeyCleanup = null;
+	}
+
+	// Map first 9 sounds to F1-F9
+	const mappings = new Map<number, HotkeyMapping>();
+	sounds.slice(0, 9).forEach((sound, index) => {
+		mappings.set(index + 1, {
+			soundId: sound.id,
+			soundName: sound.name,
+			emojiName: sound.emoji_name,
+			audioUrl: sound.audio_url,
+			volume: sound.volume,
+			durationMs: sound.duration_ms,
+		});
+	});
+	soundboardHotkeys.set(mappings);
+
+	// Audio element for playing sounds
+	let currentAudio: HTMLAudioElement | null = null;
+
+	function playSound(mapping: HotkeyMapping) {
+		// Stop any current sound
+		if (currentAudio) {
+			currentAudio.pause();
+			currentAudio = null;
+		}
+
+		// Play the sound
+		currentAudio = new Audio(mapping.audioUrl);
+		currentAudio.volume = mapping.volume;
+		currentAudio.play().catch(err => {
+			console.error('[Soundboard] Failed to play sound:', err);
+		});
+
+		// Send WebSocket event
+		sendSoundboardPlay(channelId, serverId, mapping.soundId, mapping.volume);
+
+		if (onPlay) {
+			onPlay({
+				id: mapping.soundId,
+				name: mapping.soundName,
+				emoji_name: mapping.emojiName,
+				audio_url: mapping.audioUrl,
+				volume: mapping.volume,
+				duration_ms: mapping.durationMs,
+				available: true,
+				creator_id: '',
+				created_at: '',
+			});
+		}
+
+		// Auto-stop after duration
+		setTimeout(() => {
+			if (currentAudio) {
+				currentAudio.pause();
+				currentAudio = null;
+			}
+		}, mapping.durationMs);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		// Check if we're in an input field
+		const target = event.target as HTMLElement;
+		if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+			return;
+		}
+
+		const keyIndex = HOTKEY_KEYS.indexOf(event.key);
+		if (keyIndex !== -1) {
+			event.preventDefault();
+			const mapping = mappings.get(keyIndex + 1);
+			if (mapping) {
+				playSound(mapping);
+			}
+		}
+	}
+
+	document.addEventListener('keydown', handleKeydown);
+
+	currentHotkeyCleanup = () => {
+		document.removeEventListener('keydown', handleKeydown);
+		if (currentAudio) {
+			currentAudio.pause();
+			currentAudio = null;
+		}
+	};
+
+	return currentHotkeyCleanup;
+}
+
+export function cleanupSoundboardHotkeys(): void {
+	if (currentHotkeyCleanup) {
+		currentHotkeyCleanup();
+		currentHotkeyCleanup = null;
+	}
+	soundboardHotkeys.set(new Map());
+}

--- a/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
+++ b/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
@@ -8,6 +8,10 @@
 
 	const dispatch = createEventDispatcher<{ play: { id: string; name: string; url: string; volume: number }; close: void }>();
 
+	function getHotkeyLabel(index: number): string {
+		return String(index + 1);
+	}
+
 	interface Sound {
 		id: string;
 		name: string;

--- a/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
+++ b/frontend/src/lib/components/soundboard/SoundboardPicker.svelte
@@ -334,10 +334,13 @@
 						class:playing={playingSoundId === sound.id}
 						on:click={() => playSound(sound)}
 						on:focus={() => handleSoundFocus(index)}
-						title={sound.name}
+						title="{sound.name}{index < 9 ? ` (${getHotkeyLabel(index)})` : ''}"
 						aria-label={sound.name}
 						type="button"
 					>
+						{#if index < 9}
+							<span class="hotkey-badge">{getHotkeyLabel(index)}</span>
+						{/if}
 						<span class="sound-emoji" aria-hidden="true">{sound.emoji_name || '🔊'}</span>
 						<span class="sound-name">{sound.name}</span>
 						{#if playingSoundId === sound.id}
@@ -373,6 +376,9 @@
 
 	.header {
 		padding: 12px 16px 8px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 	}
 
 	.title {
@@ -380,6 +386,14 @@
 		font-size: 14px;
 		font-weight: 600;
 		color: var(--text-primary, #f2f3f5);
+	}
+
+	.hotkey-hint {
+		font-size: 11px;
+		color: var(--text-muted, #949ba4);
+		background: var(--bg-tertiary, #1e1f22);
+		padding: 2px 6px;
+		border-radius: 4px;
 	}
 
 	.search-container {
@@ -489,6 +503,23 @@
 
 	.sound-btn.playing {
 		background: var(--bg-modifier-selected, rgba(79, 84, 92, 0.24));
+	}
+
+	.sound-btn {
+		position: relative;
+	}
+
+	.hotkey-badge {
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		font-size: 9px;
+		font-weight: 600;
+		color: var(--text-muted, #949ba4);
+		background: var(--bg-tertiary, #1e1f22);
+		padding: 1px 3px;
+		border-radius: 3px;
+		line-height: 1.2;
 	}
 
 	.sound-emoji {


### PR DESCRIPTION
- Add mock-based tests exercising CreateConversation handler:
  - handler success (mock returns conversation)
  - handler unauthorized (no user ID in context)
  - handler internal error (mock service error)
- Add mock-based tests exercising UpdateConversation handler:
  - handler success (mock returns updated conversation)
  - handler unauthorized (no user ID in context)
  - handler internal error (mock service error)
- Coverage improvement: CreateConversation 0% -> 90%, UpdateConversation 0% -> 76.5%
- Minor fix: remove broken soundboard signaling references in main.go that caused build failure
