### PR TITLE
fix(e2ee): compute identity key hash for device metadata

### DIFF
--- a/frontend/src/lib/e2ee/device-manager.ts
+++ b/frontend/src/lib/e2ee/device-manager.ts
@@ -313,7 +313,7 @@ class DeviceManagerClass {
 		await keyStorage.storeSignedPreKey(signedPreKey);
 		await keyStorage.storeOneTimePreKeys(oneTimePreKeys);
 
-		// Compute identity key hash for safety number verification
+		// Compute identity key hash for metadata storage and safety number verification
 		const identityKeyHash = await computeIdentityKeyHash(identityKey.publicKey);
 
 		// Store metadata


### PR DESCRIPTION
Replace empty identityKeyHash with computed SHA-256 hash of the
identity public key. The hash is used for device metadata storage
and safety number calculations.
