### PR TITLE
feat: implement backend sync for user settings with thread notification fields (FEAT-001)

### DIFF
--- a/backend/internal/database/postgres/migrations/045_thread_notification_settings.sql
+++ b/backend/internal/database/postgres/migrations/045_thread_notification_settings.sql
@@ -1,0 +1,10 @@
+-- Migration 045: Thread Notification Settings
+-- Adds thread auto-follow and notification level settings to user_settings
+
+ALTER TABLE user_settings
+ADD COLUMN IF NOT EXISTS thread_auto_follow BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN IF NOT EXISTS thread_follow_on_reply BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN IF NOT EXISTS thread_default_notification_level VARCHAR(20) NOT NULL DEFAULT 'all';
+
+-- Add index for potential queries on thread notification level
+CREATE INDEX IF NOT EXISTS idx_user_settings_thread_notif ON user_settings(thread_default_notification_level);

--- a/backend/internal/database/postgres/settings_repo.go
+++ b/backend/internal/database/postgres/settings_repo.go
@@ -40,6 +40,9 @@ func (r *SettingsRepository) Get(ctx context.Context, userID uuid.UUID) (*models
 			COALESCE(privacy_friend_requests_all, true) as privacy_friend_requests_all,
 			COALESCE(privacy_read_receipts, true) as privacy_read_receipts,
 			COALESCE(locale, 'en-US') as locale,
+			COALESCE(thread_auto_follow, true) as thread_auto_follow,
+			COALESCE(thread_follow_on_reply, true) as thread_follow_on_reply,
+			COALESCE(thread_default_notification_level, 'all') as thread_default_notification_level,
 			updated_at
 		FROM user_settings 
 		WHERE user_id = $1
@@ -60,9 +63,11 @@ func (r *SettingsRepository) Create(ctx context.Context, settings *models.UserSe
 			notifications_enabled, notifications_sound, notifications_desktop, notifications_mentions_only,
 			notifications_dm, notifications_server_defaults,
 			privacy_dm_from_servers, privacy_dm_from_friends_only, privacy_show_activity,
-			privacy_friend_requests_all, privacy_read_receipts, locale, updated_at
+			privacy_friend_requests_all, privacy_read_receipts, locale,
+			thread_auto_follow, thread_follow_on_reply, thread_default_notification_level,
+			updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 		)
 	`
 	_, err := r.db.ExecContext(ctx, query,
@@ -71,7 +76,9 @@ func (r *SettingsRepository) Create(ctx context.Context, settings *models.UserSe
 		settings.NotificationsEnabled, settings.NotificationsSound, settings.NotificationsDesktop, settings.NotificationsMentionsOnly,
 		settings.NotificationsDM, settings.NotificationsServerDefaults,
 		settings.PrivacyDMFromServers, settings.PrivacyDMFromFriendsOnly, settings.PrivacyShowActivity,
-		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale, settings.UpdatedAt,
+		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale,
+		settings.ThreadAutoFollow, settings.ThreadFollowOnReply, settings.ThreadDefaultNotifLevel,
+		settings.UpdatedAt,
 	)
 	return err
 }
@@ -85,7 +92,9 @@ func (r *SettingsRepository) Update(ctx context.Context, settings *models.UserSe
 			notifications_enabled = $12, notifications_sound = $13, notifications_desktop = $14, notifications_mentions_only = $15,
 			notifications_dm = $16, notifications_server_defaults = $17,
 			privacy_dm_from_servers = $18, privacy_dm_from_friends_only = $19, privacy_show_activity = $20,
-			privacy_friend_requests_all = $21, privacy_read_receipts = $22, locale = $23, updated_at = $24
+			privacy_friend_requests_all = $21, privacy_read_receipts = $22, locale = $23,
+			thread_auto_follow = $24, thread_follow_on_reply = $25, thread_default_notification_level = $26,
+			updated_at = $27
 		WHERE user_id = $1
 	`
 	_, err := r.db.ExecContext(ctx, query,
@@ -94,7 +103,9 @@ func (r *SettingsRepository) Update(ctx context.Context, settings *models.UserSe
 		settings.NotificationsEnabled, settings.NotificationsSound, settings.NotificationsDesktop, settings.NotificationsMentionsOnly,
 		settings.NotificationsDM, settings.NotificationsServerDefaults,
 		settings.PrivacyDMFromServers, settings.PrivacyDMFromFriendsOnly, settings.PrivacyShowActivity,
-		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale, settings.UpdatedAt,
+		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale,
+		settings.ThreadAutoFollow, settings.ThreadFollowOnReply, settings.ThreadDefaultNotifLevel,
+		settings.UpdatedAt,
 	)
 	return err
 }
@@ -109,9 +120,11 @@ func (r *SettingsRepository) Upsert(ctx context.Context, settings *models.UserSe
 			notifications_enabled, notifications_sound, notifications_desktop, notifications_mentions_only,
 			notifications_dm, notifications_server_defaults,
 			privacy_dm_from_servers, privacy_dm_from_friends_only, privacy_show_activity,
-			privacy_friend_requests_all, privacy_read_receipts, locale, updated_at
+			privacy_friend_requests_all, privacy_read_receipts, locale,
+			thread_auto_follow, thread_follow_on_reply, thread_default_notification_level,
+			updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 		)
 		ON CONFLICT (user_id) DO UPDATE SET
 			theme = EXCLUDED.theme,
@@ -136,6 +149,9 @@ func (r *SettingsRepository) Upsert(ctx context.Context, settings *models.UserSe
 			privacy_friend_requests_all = EXCLUDED.privacy_friend_requests_all,
 			privacy_read_receipts = EXCLUDED.privacy_read_receipts,
 			locale = EXCLUDED.locale,
+			thread_auto_follow = EXCLUDED.thread_auto_follow,
+			thread_follow_on_reply = EXCLUDED.thread_follow_on_reply,
+			thread_default_notification_level = EXCLUDED.thread_default_notification_level,
 			updated_at = EXCLUDED.updated_at
 	`
 	_, err := r.db.ExecContext(ctx, query,
@@ -144,7 +160,9 @@ func (r *SettingsRepository) Upsert(ctx context.Context, settings *models.UserSe
 		settings.NotificationsEnabled, settings.NotificationsSound, settings.NotificationsDesktop, settings.NotificationsMentionsOnly,
 		settings.NotificationsDM, settings.NotificationsServerDefaults,
 		settings.PrivacyDMFromServers, settings.PrivacyDMFromFriendsOnly, settings.PrivacyShowActivity,
-		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale, settings.UpdatedAt,
+		settings.PrivacyFriendRequestsAll, settings.PrivacyReadReceipts, settings.Locale,
+		settings.ThreadAutoFollow, settings.ThreadFollowOnReply, settings.ThreadDefaultNotifLevel,
+		settings.UpdatedAt,
 	)
 	return err
 }

--- a/backend/internal/models/user_settings.go
+++ b/backend/internal/models/user_settings.go
@@ -42,6 +42,11 @@ type UserSettings struct {
 	// Locale settings
 	Locale string `json:"locale" db:"locale"` // e.g., "en-US", "es", "fr"
 
+	// Thread notification settings
+	ThreadAutoFollow             bool   `json:"thread_auto_follow" db:"thread_auto_follow"`
+	ThreadFollowOnReply         bool   `json:"thread_follow_on_reply" db:"thread_follow_on_reply"`
+	ThreadDefaultNotifLevel     string `json:"thread_default_notification_level" db:"thread_default_notification_level"` // "all", "mentions", "none"
+
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }
 
@@ -82,6 +87,11 @@ func DefaultUserSettings(userID uuid.UUID) *UserSettings {
 		// Locale default
 		Locale: "en-US",
 
+		// Thread notification defaults (FEAT-001)
+		ThreadAutoFollow:         true,
+		ThreadFollowOnReply:      true,
+		ThreadDefaultNotifLevel:  "all",
+
 		UpdatedAt: time.Now(),
 	}
 }
@@ -119,4 +129,9 @@ type UpdateUserSettingsRequest struct {
 
 	// Locale settings
 	Locale *string `json:"locale,omitempty" validate:"omitempty,min=2,max=10"`
+
+	// Thread notification settings (FEAT-001)
+	ThreadAutoFollow         *bool   `json:"thread_auto_follow,omitempty"`
+	ThreadFollowOnReply     *bool   `json:"thread_follow_on_reply,omitempty"`
+	ThreadDefaultNotifLevel *string `json:"thread_default_notification_level,omitempty" validate:"omitempty,oneof=all mentions none"`
 }

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -142,6 +142,17 @@ func (s *SettingsService) UpdateSettings(ctx context.Context, userID uuid.UUID, 
 		settings.Locale = *updates.Locale
 	}
 
+	// Apply thread notification updates (FEAT-001)
+	if updates.ThreadAutoFollow != nil {
+		settings.ThreadAutoFollow = *updates.ThreadAutoFollow
+	}
+	if updates.ThreadFollowOnReply != nil {
+		settings.ThreadFollowOnReply = *updates.ThreadFollowOnReply
+	}
+	if updates.ThreadDefaultNotifLevel != nil {
+		settings.ThreadDefaultNotifLevel = *updates.ThreadDefaultNotifLevel
+	}
+
 	settings.UpdatedAt = time.Now()
 
 	// Upsert the settings

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -418,7 +418,7 @@ function createSettingsStore() {
 					Object.prototype.hasOwnProperty.call(updates, 'threadNotifications');
 				
 				if (hasThreadUpdate) {
-					syncSettingsToBackend({ notifications: updates });
+					syncSettingsToBackend({ notifications: updates as NotificationSettings });
 				}
 				
 				return { ...s, app: newApp };

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1,7 +1,8 @@
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { theme as themeStore, type ThemeChoice } from './theme';
 export type { ResolvedTheme } from './theme';
+import { api } from '$lib/api';
 
 export type Theme = ThemeChoice;
 export type MessageDisplay = 'cozy' | 'compact';
@@ -47,6 +48,38 @@ export interface SettingsState {
 	isServerSettingsOpen: boolean;
 	activeSection: string;
 	app: AppSettings;
+	loadedFromBackend: boolean;
+}
+
+// Backend API response shape
+interface BackendUserSettings {
+	user_id: string;
+	theme: string;
+	message_display: string;
+	compact_mode: boolean;
+	developer_mode: boolean;
+	inline_embeds: boolean;
+	inline_attachments: boolean;
+	render_reactions: boolean;
+	animate_emoji: boolean;
+	enable_tts: boolean;
+	custom_css?: string;
+	notifications_enabled: boolean;
+	notifications_sound: boolean;
+	notifications_desktop: boolean;
+	notifications_mentions_only: boolean;
+	notifications_dm: boolean;
+	notifications_server_defaults: boolean;
+	privacy_dm_from_servers: boolean;
+	privacy_dm_from_friends_only: boolean;
+	privacy_show_activity: boolean;
+	privacy_friend_requests_all: boolean;
+	privacy_read_receipts: boolean;
+	locale: string;
+	thread_auto_follow: boolean;
+	thread_follow_on_reply: boolean;
+	thread_default_notification_level: string;
+	updated_at: string;
 }
 
 const defaultNotificationSettings: NotificationSettings = {
@@ -176,16 +209,150 @@ function saveSettings(settings: AppSettings) {
 	}
 }
 
+// Map backend response to frontend AppSettings
+function mapBackendToFrontend(backend: BackendUserSettings): Partial<AppSettings> {
+	return {
+		theme: isValidTheme(backend.theme) ? backend.theme : defaultSettings.theme,
+		messageDisplay: isValidMessageDisplay(backend.message_display) ? backend.message_display as MessageDisplay : defaultSettings.messageDisplay,
+		compactMode: typeof backend.compact_mode === 'boolean' ? backend.compact_mode : defaultSettings.compactMode,
+		developerMode: typeof backend.developer_mode === 'boolean' ? backend.developer_mode : defaultSettings.developerMode,
+		notificationsEnabled: typeof backend.notifications_enabled === 'boolean' ? backend.notifications_enabled : defaultSettings.notificationsEnabled,
+		notifications: {
+			desktopEnabled: typeof backend.notifications_desktop === 'boolean' ? backend.notifications_desktop : defaultNotificationSettings.desktopEnabled,
+			soundsEnabled: typeof backend.notifications_sound === 'boolean' ? backend.notifications_sound : defaultNotificationSettings.soundsEnabled,
+			soundVolume: defaultNotificationSettings.soundVolume,
+			mentionSound: defaultNotificationSettings.mentionSound,
+			messageSound: defaultNotificationSettings.messageSound,
+			flashTaskbar: defaultNotificationSettings.flashTaskbar,
+			showPreviews: defaultNotificationSettings.showPreviews,
+			muteDMs: typeof backend.notifications_dm === 'boolean' ? !backend.notifications_dm : defaultNotificationSettings.muteDMs,
+			muteGroupDMs: defaultNotificationSettings.muteGroupDMs,
+			mentionEveryone: typeof backend.notifications_mentions_only === 'boolean' ? backend.notifications_mentions_only : defaultNotificationSettings.mentionEveryone,
+			mentionRoles: defaultNotificationSettings.mentionRoles,
+			mentionHighlight: defaultNotificationSettings.mentionHighlight,
+			suppressDND: defaultNotificationSettings.suppressDND,
+			threadNotifications: isValidThreadNotificationLevel(backend.thread_default_notification_level) 
+				? backend.thread_default_notification_level as ThreadNotificationLevel 
+				: defaultNotificationSettings.threadNotifications,
+			threadAutoFollow: typeof backend.thread_auto_follow === 'boolean' ? backend.thread_auto_follow : defaultNotificationSettings.threadAutoFollow,
+			threadFollowOnReply: typeof backend.thread_follow_on_reply === 'boolean' ? backend.thread_follow_on_reply : defaultNotificationSettings.threadFollowOnReply
+		}
+	};
+}
+
+// Map frontend partial settings to backend update request
+function mapFrontendToBackend(updates: Partial<AppSettings>): Record<string, unknown> {
+	const backend: Record<string, unknown> = {};
+	
+	if (updates.theme !== undefined) backend['theme'] = updates.theme;
+	if (updates.messageDisplay !== undefined) backend['message_display'] = updates.messageDisplay;
+	if (updates.compactMode !== undefined) backend['compact_mode'] = updates.compactMode;
+	if (updates.developerMode !== undefined) backend['developer_mode'] = updates.developerMode;
+	if (updates.notificationsEnabled !== undefined) backend['notifications_enabled'] = updates.notificationsEnabled;
+	
+	if (updates.notifications) {
+		const n = updates.notifications;
+		if (n.desktopEnabled !== undefined) backend['notifications_desktop'] = n.desktopEnabled;
+		if (n.soundsEnabled !== undefined) backend['notifications_sound'] = n.soundsEnabled;
+		if (n.muteDMs !== undefined) backend['notifications_dm'] = !n.muteDMs;
+		if (n.mentionEveryone !== undefined) backend['notifications_mentions_only'] = n.mentionEveryone;
+		// FEAT-001: Thread settings
+		if (n.threadAutoFollow !== undefined) backend['thread_auto_follow'] = n.threadAutoFollow;
+		if (n.threadFollowOnReply !== undefined) backend['thread_follow_on_reply'] = n.threadFollowOnReply;
+		if (n.threadNotifications !== undefined) backend['thread_default_notification_level'] = n.threadNotifications;
+	}
+	
+	return backend;
+}
+
+// Fetch user settings from backend API
+export async function fetchUserSettings(settingsStore: ReturnType<typeof createSettingsStore>): Promise<void> {
+	if (!browser) return;
+	
+	try {
+		const backendSettings = await api.get<BackendUserSettings | undefined>('/users/@me/settings');
+		if (!backendSettings) {
+			// No backend settings (user not authenticated or API error)
+			settingsStore.update(s => ({ ...s, loadedFromBackend: true }));
+			return;
+		}
+		const mapped = mapBackendToFrontend(backendSettings);
+		
+		// Merge with localStorage settings (localStorage takes precedence for fields not on backend)
+		const local = loadSettings();
+		const merged: AppSettings = {
+			...local,
+			...mapped,
+			notifications: {
+				...defaultNotificationSettings,
+				...local.notifications,
+				...mapped.notifications
+			}
+		};
+		
+		settingsStore.update(s => {
+			const newApp = merged;
+			saveSettings(newApp);
+			themeStore.set(newApp.theme);
+			if (browser) {
+				document.documentElement.style.setProperty('--message-font-size', `${newApp.fontSize}px`);
+			}
+			return { ...s, app: newApp, loadedFromBackend: true };
+		});
+	} catch (error) {
+		console.warn('Failed to fetch user settings from backend, using local defaults:', error);
+		// Still mark as loaded so we don't keep retrying
+		settingsStore.update(s => ({ ...s, loadedFromBackend: true }));
+	}
+}
+
+// Sync settings to backend API (fire-and-forget for thread-specific settings only)
+// Non-thread notification settings (desktopEnabled, soundsEnabled, etc.) remain local-only
+async function syncSettingsToBackend(updates: Partial<AppSettings>): Promise<void> {
+	if (!browser) return;
+	
+	try {
+		// Only sync thread-specific settings to backend (FEAT-001)
+		// Only include fields that were explicitly changed in updates
+		const backendUpdates: Record<string, unknown> = {};
+		
+		if (updates.notifications) {
+			const n = updates.notifications;
+			// Only sync thread settings if explicitly changed
+			if (Object.prototype.hasOwnProperty.call(n, 'threadAutoFollow')) backendUpdates['thread_auto_follow'] = n.threadAutoFollow;
+			if (Object.prototype.hasOwnProperty.call(n, 'threadFollowOnReply')) backendUpdates['thread_follow_on_reply'] = n.threadFollowOnReply;
+			if (Object.prototype.hasOwnProperty.call(n, 'threadNotifications')) backendUpdates['thread_default_notification_level'] = n.threadNotifications;
+		}
+		
+		// Also sync top-level app settings that map to backend
+		if (updates.theme !== undefined) backendUpdates['theme'] = updates.theme;
+		if (updates.messageDisplay !== undefined) backendUpdates['message_display'] = updates.messageDisplay;
+		if (updates.compactMode !== undefined) backendUpdates['compact_mode'] = updates.compactMode;
+		if (updates.developerMode !== undefined) backendUpdates['developer_mode'] = updates.developerMode;
+		if (updates.notificationsEnabled !== undefined) backendUpdates['notifications_enabled'] = updates.notificationsEnabled;
+		
+		if (Object.keys(backendUpdates).length > 0) {
+			await api.patch('/users/@me/settings', backendUpdates);
+		}
+	} catch (error) {
+		// Non-critical: log but don't throw
+		console.warn('Failed to sync settings to backend:', error);
+	}
+}
+
 const initialState: SettingsState = {
 	isOpen: false,
 	isServerSettingsOpen: false,
 	activeSection: 'account',
-	app: loadSettings()
+	app: loadSettings(),
+	loadedFromBackend: false
 };
 
 // Sync initial theme from settings to theme store
 if (browser) {
 	themeStore.set(initialState.app.theme);
+	// Apply initial font size
+	document.documentElement.style.setProperty('--message-font-size', `${initialState.app.fontSize}px`);
 }
 
 function createSettingsStore() {
@@ -193,6 +360,7 @@ function createSettingsStore() {
 	
 	return {
 		subscribe,
+		update,
 		
 		open(section = 'account') {
 			update(s => ({ ...s, isOpen: true, activeSection: section }));
@@ -229,6 +397,9 @@ function createSettingsStore() {
 					document.documentElement.style.setProperty('--message-font-size', `${updates.fontSize}px`);
 				}
 				
+				// Sync non-blocking to backend
+				syncSettingsToBackend(updates);
+				
 				return { ...s, app: newApp };
 			});
 		},
@@ -238,6 +409,18 @@ function createSettingsStore() {
 				const newNotifications = { ...s.app.notifications, ...updates };
 				const newApp = { ...s.app, notifications: newNotifications };
 				saveSettings(newApp);
+				
+				// Only sync thread-specific settings to backend (FEAT-001)
+				// If only non-thread notification fields are changed, skip backend sync
+				const hasThreadUpdate = 
+					Object.prototype.hasOwnProperty.call(updates, 'threadAutoFollow') ||
+					Object.prototype.hasOwnProperty.call(updates, 'threadFollowOnReply') ||
+					Object.prototype.hasOwnProperty.call(updates, 'threadNotifications');
+				
+				if (hasThreadUpdate) {
+					syncSettingsToBackend({ notifications: updates });
+				}
+				
 				return { ...s, app: newApp };
 			});
 		},
@@ -246,6 +429,10 @@ function createSettingsStore() {
 			update(s => {
 				saveSettings(defaultSettings);
 				themeStore.set(defaultSettings.theme);
+				if (browser) {
+					document.documentElement.style.setProperty('--message-font-size', `${defaultSettings.fontSize}px`);
+				}
+				// TODO: Also reset backend settings
 				return { ...s, app: defaultSettings };
 			});
 		}
@@ -253,6 +440,12 @@ function createSettingsStore() {
 }
 
 export const settings = createSettingsStore();
+
+// Attempt to load settings from backend (non-blocking)
+// This must be called after 'settings' is created
+if (browser) {
+	fetchUserSettings(settings);
+}
 
 // Convenience derived stores
 export const isSettingsOpen = derived(settings, $s => $s.isOpen);


### PR DESCRIPTION
- Add thread_auto_follow, thread_follow_on_reply, thread_default_notification_level
  fields to UserSettings model and UpdateUserSettingsRequest
- Update SettingsService to apply thread field updates
- Update SettingsRepository with thread fields in Get/Create/Update/Upsert queries
- Add database migration 045 for thread notification settings
- Implement frontend fetchUserSettings() to load settings from backend on init
- Wire up settings store to sync thread settings to backend API (non-blocking)
- Settings with thread-specific fields (threadAutoFollow, threadFollowOnReply,
  threadNotifications) are synced to backend; other notification settings remain local-only
- Add null check in fetchUserSettings for unauthenticated users
