### PR TITLE
fix(tests): enable backend sync tests for settings store

### DIFF
--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -52,7 +52,7 @@ Object.defineProperty(global, 'document', {
 });
 
 // Now import the module under test
-import { settings, notificationSettings } from './settings';
+import { settings, notificationSettings, fetchUserSettings } from './settings';
 
 describe('Settings Store', () => {
 	beforeEach(() => {
@@ -99,8 +99,7 @@ describe('Settings Store', () => {
 			expect(notifications.threadNotifications).toBe('mentions');
 		});
 
-		it.skip('should sync thread settings to backend when updated', async () => {
-			// TODO: Backend sync not yet implemented - settings only persist to localStorage
+		it('should sync thread settings to backend when updated', async () => {
 			mockApi.patch.mockResolvedValue({});
 			
 			settings.updateNotifications({ threadAutoFollow: false });
@@ -113,8 +112,7 @@ describe('Settings Store', () => {
 			}));
 		});
 
-		it.skip('should sync all thread settings to backend', async () => {
-			// TODO: Backend sync not yet implemented - settings only persist to localStorage
+		it('should sync all thread settings to backend', async () => {
 			mockApi.patch.mockResolvedValue({});
 			
 			settings.updateNotifications({ 
@@ -144,15 +142,14 @@ describe('Settings Store', () => {
 			expect(mockApi.patch).not.toHaveBeenCalled();
 		});
 
-		// TODO: fetchUserSettings not yet implemented - settings currently use localStorage only
-		it.skip('should fetch thread settings from backend', async () => {
+		it('should fetch thread settings from backend', async () => {
 			mockApi.get.mockResolvedValue({
 				thread_auto_follow: false,
 				thread_follow_on_reply: false,
 				thread_default_notification_level: 'mentions'
 			});
 			
-			// await fetchUserSettings();
+			await fetchUserSettings(settings);
 			
 			const notifications = get(notificationSettings);
 			expect(notifications.threadAutoFollow).toBe(false);
@@ -160,12 +157,11 @@ describe('Settings Store', () => {
 			expect(notifications.threadNotifications).toBe('mentions');
 		});
 
-		// TODO: fetchUserSettings not yet implemented - settings currently use localStorage only
-		it.skip('should use local defaults if backend fetch fails', async () => {
+		it('should use local defaults if backend fetch fails', async () => {
 			mockApi.get.mockRejectedValue(new Error('Network error'));
 			
 			// Should not throw
-			// await fetchUserSettings();
+			await fetchUserSettings(settings);
 			
 			const notifications = get(notificationSettings);
 			// Should still have defaults


### PR DESCRIPTION
Enable 4 skipped tests that were pending backend sync implementation:
- 'should sync thread settings to backend when updated'
- 'should sync all thread settings to backend'
- 'should fetch thread settings from backend'
- 'should use local defaults if backend fetch fails'

Backend sync (fetchUserSettings) was implemented in FEAT-001, so these
tests now validate the actual backend integration path.
