### PR TITLE
chore(e2ee): remove dead stub code for future libsignal WASM integration

### DIFF
--- a/frontend/src/lib/e2ee/keys.ts
+++ b/frontend/src/lib/e2ee/keys.ts
@@ -2,10 +2,7 @@
  * E2EE Key Storage - IndexedDB Layer
  * 
  * This module provides IndexedDB storage for E2EE keys.
- * 
- * For Phase 1 (DM Foundation), we use the WebCrypto-based implementation
- * in crypto/keys.ts. The libsignal-client WASM integration is a future
- * enhancement for when we need the full Signal Protocol implementation.
+ * Uses the WebCrypto-based implementation in crypto/keys.ts.
  * 
  * Storage Schema:
  * - identityKeys: Device identity key pairs
@@ -43,67 +40,4 @@ export {
 
 export { KeyStore };
 
-// ============================================================================
-// libsignal-client WASM Integration (Future Enhancement)
-// ============================================================================
-// The following functions are stubs for libsignal-client WASM integration.
-// They will be implemented when we upgrade from WebCrypto to libsignal-client
-// for full Signal Protocol compliance.
-//
-// For now, we use the WebCrypto-based X3DH implementation in crypto/signal-protocol.ts
 
-/**
- * Stub: Initialize libsignal-client WASM module
- * 
- * This will be implemented when we integrate libsignal-client WASM.
- * The WASM module provides:
- * - Curve25519 key operations (instead of P-256 in WebCrypto)
- * - Double Ratchet algorithm implementation
- * - Proper Signal Protocol session management
- */
-export async function initializeWasm(): Promise<void> {
-  console.debug('libsignal-client WASM initialization deferred to future enhancement');
-  // TODO: Load and initialize libsignal-client WASM
-  // import init from 'libsignal-client';
-  // await init();
-}
-
-/**
- * Stub: Generate identity key using libsignal-client
- */
-export async function generateIdentityKey(): Promise<IdentityKeyPair> {
-  // Fall back to WebCrypto implementation
-  const keyPair = await crypto.subtle.generateKey(
-    { name: 'ECDH', namedCurve: 'P-256' },
-    true,
-    ['deriveBits', 'deriveKey']
-  );
-  return {
-    publicKey: keyPair.publicKey,
-    privateKey: keyPair.privateKey,
-  } as IdentityKeyPair;
-}
-
-/**
- * Stub: Store session record (libsignal-client format)
- * 
- * libsignal-client stores sessions as serialized SessionRecord objects.
- * For now, we store session state in our own format in crypto/secure-storage.ts
- */
-export async function storeSessionRecord(): Promise<void> {
-  throw new Error('libsignal-client WASM not yet integrated - use WebCrypto session management');
-}
-
-/**
- * Stub: Get session record (libsignal-client format)
- */
-export async function getSessionRecord(): Promise<unknown> {
-  throw new Error('libsignal-client WASM not yet integrated - use WebCrypto session management');
-}
-
-/**
- * Stub: Process prekey bundle and create session
- */
-export async function processPreKeyBundle(): Promise<void> {
-  throw new Error('libsignal-client WASM not yet integrated - use WebCrypto X3DH');
-}


### PR DESCRIPTION
These stubs (initializeWasm, generateIdentityKey, storeSessionRecord,
getSessionRecord, processPreKeyBundle) were never used anywhere in the codebase.
All actual WASM initialization flows through wasm-loader.ts which has the
proper implementation with WebCrypto fallback.

Removed the entire 'libsignal-client WASM Integration (Future Enhancement)'
section from keys.ts along with the misleading TODO comment. The module
now only contains active re-exports from crypto/keys.ts.

This resolves the P2 TODO item from the tech debt queue:
[e2ee/keys.ts:66] TODO: Load and initialize libsignal-client WASM
