### PR TITLE
feat(ratelimit): Add per-user invite creation rate limiting

### DIFF
--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -260,6 +260,18 @@ func main() {
 		redisCache, // cache
 		serviceBus,
 	)
+
+	// Initialize invite rate limiter
+	// Note: redisLimiter is created later in the middleware section, so we use
+	// a memory-based rate limiter for now. The invite rate limiter can be updated
+	// to use Redis when it's available.
+	var inviteRateLimiter services.InviteRateLimiter
+	if cfg.RateLimitEnabled {
+		inviteRateLimiter = services.NewMemoryInviteRateLimiter(services.DefaultInviteRateLimiterConfig())
+		serverService.SetInviteRateLimiter(inviteRateLimiter)
+		log.Printf("✅ Invite rate limiter wired (memory-based, 5 invites/hour)")
+	}
+
 	channelService := services.NewChannelService(
 		repos.Channels,
 		repos.Servers,

--- a/backend/internal/api/handlers/invites.go
+++ b/backend/internal/api/handlers/invites.go
@@ -101,6 +101,12 @@ func (h *InviteHandlers) CreateInvite(c *fiber.Ctx) error {
 		Temporary: req.Temporary,
 	})
 	if err != nil {
+		if err == services.ErrInviteRateLimited {
+			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+				"error":   "rate_limited",
+				"message":  "Too many invites created. Please wait before creating more.",
+			})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),
 		})

--- a/backend/internal/services/errors.go
+++ b/backend/internal/services/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrInviteNotFound    = errors.New("invite not found")
 	ErrInviteExpired     = errors.New("invite has expired")
 	ErrInviteMaxUses     = errors.New("invite has reached maximum uses")
+	ErrInviteRateLimited = errors.New("too many invites created recently")
 	ErrVanityCodeTaken   = errors.New("vanity code is already taken")
 	ErrVanityCodeInvalid = errors.New("vanity code must be 3-32 characters and contain only letters, numbers, hyphens, and underscores")
 

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -53,6 +53,13 @@ type ComponentRateLimiter interface {
 	CheckModalSubmit(ctx context.Context, userID uuid.UUID) error
 }
 
+// InviteRateLimiter defines rate limiting for invite creation
+type InviteRateLimiter interface {
+	// CheckInviteCreation checks rate limit for invite creation
+	// Returns nil if allowed, ErrInviteRateLimited if rate limited
+	CheckInviteCreation(ctx context.Context, userID uuid.UUID) error
+}
+
 // E2EEService defines E2EE operations
 type E2EEService interface {
 	// Validate that a payload is properly formatted encrypted content

--- a/backend/internal/services/invite_ratelimit.go
+++ b/backend/internal/services/invite_ratelimit.go
@@ -1,0 +1,181 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"hearth/internal/ratelimit"
+)
+
+// DefaultInviteRateLimit is the default maximum invites per user per hour
+const DefaultInviteRateLimit = 5
+
+// DefaultInviteRateWindow is the default time window for invite rate limiting
+const DefaultInviteRateWindow = 1 * time.Hour
+
+// InviteRateLimiterConfig holds configuration for invite rate limiting
+type InviteRateLimiterConfig struct {
+	// MaxInvites is the maximum number of invites allowed per window
+	MaxInvites int
+	// Window is the duration of the rate limit window
+	Window time.Duration
+}
+
+// DefaultInviteRateLimiterConfig returns the default configuration
+func DefaultInviteRateLimiterConfig() InviteRateLimiterConfig {
+	return InviteRateLimiterConfig{
+		MaxInvites: DefaultInviteRateLimit,
+		Window:     DefaultInviteRateWindow,
+	}
+}
+
+// RedisInviteRateLimiter implements InviteRateLimiter using Redis
+type RedisInviteRateLimiter struct {
+	redisLimiter *ratelimit.RedisLimiter
+	config       InviteRateLimiterConfig
+}
+
+// NewRedisInviteRateLimiter creates a new Redis-backed invite rate limiter
+func NewRedisInviteRateLimiter(redisLimiter *ratelimit.RedisLimiter, config InviteRateLimiterConfig) *RedisInviteRateLimiter {
+	if config.MaxInvites == 0 {
+		config.MaxInvites = DefaultInviteRateLimit
+	}
+	if config.Window == 0 {
+		config.Window = DefaultInviteRateWindow
+	}
+	return &RedisInviteRateLimiter{
+		redisLimiter: redisLimiter,
+		config:       config,
+	}
+}
+
+// CheckInviteCreation checks if the user can create an invite
+func (r *RedisInviteRateLimiter) CheckInviteCreation(ctx context.Context, userID uuid.UUID) error {
+	result, err := r.redisLimiter.CheckUser(ctx, userID, "invite", r.config.MaxInvites, r.config.Window)
+	if err != nil {
+		// On error, allow the request (fail open)
+		return nil
+	}
+
+	if !result.Allowed {
+		return ErrInviteRateLimited
+	}
+
+	return nil
+}
+
+// MemoryInviteRateLimiter implements InviteRateLimiter using in-memory storage
+type MemoryInviteRateLimiter struct {
+	config InviteRateLimiterConfig
+	// userWindows stores the start time of each user's current window
+	userWindows map[uuid.UUID]windowState
+}
+
+type windowState struct {
+	start     time.Time
+	count     int
+	windowEnd time.Time
+}
+
+// NewMemoryInviteRateLimiter creates a new in-memory invite rate limiter
+func NewMemoryInviteRateLimiter(config InviteRateLimiterConfig) *MemoryInviteRateLimiter {
+	if config.MaxInvites == 0 {
+		config.MaxInvites = DefaultInviteRateLimit
+	}
+	if config.Window == 0 {
+		config.Window = DefaultInviteRateWindow
+	}
+	return &MemoryInviteRateLimiter{
+		config:     config,
+		userWindows: make(map[uuid.UUID]windowState),
+	}
+}
+
+// CheckInviteCreation checks if the user can create an invite
+func (r *MemoryInviteRateLimiter) CheckInviteCreation(ctx context.Context, userID uuid.UUID) error {
+	now := time.Now()
+
+	state, exists := r.userWindows[userID]
+	if !exists || now.After(state.windowEnd) {
+		// Start a new window
+		r.userWindows[userID] = windowState{
+			start:     now,
+			count:     1,
+			windowEnd: now.Add(r.config.Window),
+		}
+		return nil
+	}
+
+	// Within window, check count
+	if state.count >= r.config.MaxInvites {
+		return ErrInviteRateLimited
+	}
+
+	// Increment count
+	state.count++
+	r.userWindows[userID] = state
+	return nil
+}
+
+// CacheInviteRateLimiter implements InviteRateLimiter using the cache service
+// This provides persistence across service restarts
+type CacheInviteRateLimiter struct {
+	cache   CacheService
+	config  InviteRateLimiterConfig
+}
+
+// NewCacheInviteRateLimiter creates a new cache-backed invite rate limiter
+func NewCacheInviteRateLimiter(cache CacheService, config InviteRateLimiterConfig) *CacheInviteRateLimiter {
+	if config.MaxInvites == 0 {
+		config.MaxInvites = DefaultInviteRateLimit
+	}
+	if config.Window == 0 {
+		config.Window = DefaultInviteRateWindow
+	}
+	return &CacheInviteRateLimiter{
+		cache:  cache,
+		config: config,
+	}
+}
+
+// cacheKey returns the cache key for a user's invite rate limit
+func (r *CacheInviteRateLimiter) cacheKey(userID uuid.UUID) string {
+	return fmt.Sprintf("invite_ratelimit:%s", userID.String())
+}
+
+// CheckInviteCreation checks if the user can create an invite
+func (r *CacheInviteRateLimiter) CheckInviteCreation(ctx context.Context, userID uuid.UUID) error {
+	key := r.cacheKey(userID)
+
+	// Try to get existing count
+	data, err := r.cache.Get(ctx, key)
+	if err != nil || len(data) == 0 {
+		// No existing entry, allow and set initial count
+		err := r.cache.Set(ctx, key, []byte("1"), r.config.Window)
+		if err != nil {
+			// Cache error, allow the request
+			return nil
+		}
+		return nil
+	}
+
+	// Parse existing count - data is a byte slice
+	var count int
+	_, parseErr := fmt.Sscanf(string(data), "%d", &count)
+	if parseErr != nil {
+		// Invalid data, reset
+		r.cache.Set(ctx, key, []byte("1"), r.config.Window)
+		return nil
+	}
+
+	if count >= r.config.MaxInvites {
+		return ErrInviteRateLimited
+	}
+
+	// Increment count - note: this is not atomic, but for rate limiting it's acceptable
+	newCount := count + 1
+	r.cache.Set(ctx, key, []byte(fmt.Sprintf("%d", newCount)), r.config.Window)
+	return nil
+}

--- a/backend/internal/services/invite_service.go
+++ b/backend/internal/services/invite_service.go
@@ -31,12 +31,13 @@ type BanRepository interface {
 
 // InviteService handles invite-related business logic
 type InviteService struct {
-	inviteRepo  InviteRepository
-	banRepo     BanRepository
-	serverRepo  ServerRepository
-	permService *PermissionService
-	cache       CacheService
-	eventBus    EventBus
+	inviteRepo    InviteRepository
+	banRepo       BanRepository
+	serverRepo    ServerRepository
+	permService   *PermissionService
+	cache         CacheService
+	eventBus      EventBus
+	rateLimiter   InviteRateLimiter
 }
 
 // NewInviteService creates a new invite service
@@ -56,6 +57,11 @@ func NewInviteService(
 		cache:       cache,
 		eventBus:    eventBus,
 	}
+}
+
+// SetInviteRateLimiter sets the rate limiter for invite creation
+func (s *InviteService) SetInviteRateLimiter(rateLimiter InviteRateLimiter) {
+	s.rateLimiter = rateLimiter
 }
 
 // CreateInviteRequest represents an invite creation request
@@ -79,6 +85,13 @@ func (s *InviteService) CreateInvite(ctx context.Context, req *CreateInviteReque
 	// Check CREATE_INVITE permission
 	if s.permService != nil {
 		if err := s.permService.RequirePermission(ctx, req.ServerID, req.CreatorID, models.PermCreateInvite); err != nil {
+			return nil, err
+		}
+	}
+
+	// Check invite creation rate limit
+	if s.rateLimiter != nil {
+		if err := s.rateLimiter.CheckInviteCreation(ctx, req.CreatorID); err != nil {
 			return nil, err
 		}
 	}

--- a/backend/internal/services/server_service.go
+++ b/backend/internal/services/server_service.go
@@ -58,14 +58,15 @@ type ServerRepository interface {
 
 // ServerService handles server-related business logic
 type ServerService struct {
-	repo         ServerRepository
-	channelRepo  ChannelRepository
-	roleRepo     RoleRepository
-	messageRepo  MessageRepository
-	quotaService *QuotaService
-	permService  *PermissionService
-	cache        CacheService
-	eventBus     EventBus
+	repo             ServerRepository
+	channelRepo      ChannelRepository
+	roleRepo         RoleRepository
+	messageRepo      MessageRepository
+	quotaService     *QuotaService
+	permService      *PermissionService
+	cache            CacheService
+	eventBus         EventBus
+	inviteRateLimiter InviteRateLimiter
 }
 
 // NewServerService creates a new server service
@@ -89,6 +90,11 @@ func NewServerService(
 		cache:        cache,
 		eventBus:     eventBus,
 	}
+}
+
+// SetInviteRateLimiter sets the rate limiter for invite creation
+func (s *ServerService) SetInviteRateLimiter(rateLimiter InviteRateLimiter) {
+	s.inviteRateLimiter = rateLimiter
 }
 
 // CreateServer creates a new server
@@ -587,6 +593,13 @@ func (s *ServerService) CreateInvite(ctx context.Context, serverID, channelID, c
 	// Require CREATE_INVITE permission
 	if s.permService != nil {
 		if err := s.permService.RequirePermission(ctx, serverID, creatorID, models.PermCreateInvite); err != nil {
+			return nil, err
+		}
+	}
+
+	// Check invite creation rate limit
+	if s.inviteRateLimiter != nil {
+		if err := s.inviteRateLimiter.CheckInviteCreation(ctx, creatorID); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Implements per-user invite creation rate limiting (5 invites/hour default).

Changes:
- Add ErrInviteRateLimited error in services/errors.go
- Add InviteRateLimiter interface in services/interfaces.go
- Add invite rate limiter field and setter to ServerService
- Add rate limit check in ServerService.CreateInvite()
- Implement RedisInviteRateLimiter and MemoryInviteRateLimiter
- Wire up invite rate limiter in main.go
- Update InviteHandler to return 429 when rate limited

This addresses the rate limiting item from the security-ratelimiting-abuse.md:
- [MEDIUM] Add per-user invite creation rate limits (5/hour default)
