### PR TITLE
feat(frontend): insert @mention from member list context menu

### DIFF
--- a/frontend/src/lib/components/MemberList.svelte
+++ b/frontend/src/lib/components/MemberList.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { currentServer } from '$lib/stores/servers';
+	import { currentChannel } from '$lib/stores/channels';
 	import { members, roles, loadServerMembers, loadServerRoles } from '$lib/stores/members';
 	import { presenceStore, type PresenceStatus, type Activity, getActivityLabel } from '$lib/stores/presence';
 	import { popoutStore } from '$lib/stores/popout';
 	import { handleListKeyboard } from '$lib/utils/keyboard';
 	import { createDM } from '$lib/stores/channels';
+	import { messageInputSuggestion } from '$lib/stores/messageInputSuggestion';
 	import Avatar from './Avatar.svelte';
 	import ContextMenu from './ContextMenu.svelte';
 	import ContextMenuItem from './ContextMenuItem.svelte';
@@ -284,12 +286,31 @@
 		}
 	}
 
-	function handleMentionUser() {
+	async function handleMentionUser() {
 		if (!contextMenuMember) return;
 		showContextMenu = false;
-		// Copy @mention to clipboard for easy pasting into message input
+
 		const mention = `<@${contextMenuMember.user.id}>`;
-		navigator.clipboard.writeText(mention);
+		const channel = $currentChannel;
+
+		// If we're already in a DM with this user, insert mention directly
+		if (channel?.type === 1 && channel.recipients?.some(r => r.id === contextMenuMember!.user.id)) {
+			messageInputSuggestion.insertMention(mention);
+			return;
+		}
+
+		// Otherwise navigate to DM then insert mention
+		try {
+			const dmChannel = await createDM(contextMenuMember.user.id);
+			// Navigate to DM, then insert mention after mount
+			goto(`/channels/@me/${dmChannel.id}`);
+			// The MessageInput on the new page will pick up the pending mention
+			messageInputSuggestion.insertMention(mention);
+		} catch (err) {
+			// Fallback to clipboard if DM creation fails
+			console.error('[MemberList] Failed to open DM for mention:', err);
+			navigator.clipboard.writeText(mention);
+		}
 	}
 
 	function handleCopyUserId() {

--- a/frontend/src/lib/components/MessageInput.svelte
+++ b/frontend/src/lib/components/MessageInput.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount, tick } from 'svelte';
 	import { currentChannel } from '$lib/stores/channels';
 	import { sendTypingIndicator } from '$lib/stores/messages';
 	import { uploadStore } from '$lib/stores/uploads';
+	import { messageInputSuggestion } from '$lib/stores/messageInputSuggestion';
 	import EmojiPicker from './EmojiPicker.svelte';
 	import GifPicker from './GifPicker.svelte';
 	import FileUploadZone from './FileUploadZone.svelte';
@@ -46,6 +47,37 @@
 	$: showUploadProgress = uploadItems.length > 0;
 
 	$: actualPlaceholder = placeholder || getPlaceholder($currentChannel);
+
+	// Handle pending mention insertions from other components (e.g. MemberList context menu)
+	$: if ($messageInputSuggestion?.type === 'mention') {
+		insertMention($messageInputSuggestion.value);
+		messageInputSuggestion.clear();
+	}
+
+	/**
+	 * Inserts a string (e.g. mention) at the current cursor position in the textarea.
+	 * Falls back to appending at end if textarea is not available.
+	 */
+	function insertMention(mention: string) {
+		if (!textarea) {
+			// Fallback: just append to content if textarea ref not yet set
+			content += mention;
+			return;
+		}
+		const start = textarea.selectionStart ?? content.length;
+		const end = textarea.selectionEnd ?? content.length;
+		const before = content.substring(0, start);
+		const after = content.substring(end);
+		content = before + mention + after;
+		// Move cursor after the inserted mention
+		tick().then(() => {
+			if (textarea) {
+				const newPos = start + mention.length;
+				textarea.setSelectionRange(newPos, newPos);
+				textarea.focus();
+			}
+		});
+	}
 
 	function getPlaceholder(channel: typeof $currentChannel) {
 		if (!channel) return 'Message';

--- a/frontend/src/lib/stores/messageInputSuggestion.ts
+++ b/frontend/src/lib/stores/messageInputSuggestion.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Store for cross-component message input suggestions.
+ * Used by components like MemberList to insert mentions into the active message input.
+ */
+export interface MessageInputSuggestion {
+	type: 'mention';
+	value: string; // e.g. `<@user-id>`
+}
+
+function createMessageInputSuggestionStore() {
+	const { subscribe, set } = writable<MessageInputSuggestion | null>(null);
+
+	return {
+		subscribe,
+		/**
+		 * Request insertion of a mention string into the message input.
+		 */
+		insertMention(mention: string) {
+			set({ type: 'mention', value: mention });
+		},
+		/**
+		 * Clear any pending suggestion.
+		 */
+		clear() {
+			set(null);
+		}
+	};
+}
+
+export const messageInputSuggestion = createMessageInputSuggestionStore();


### PR DESCRIPTION
Previously, right-clicking a member and selecting 'Mention' only copied
the mention string to clipboard. Now it inserts the mention directly
into the message input:

- If already in a DM with the member: inserts at cursor position
- If not: navigates to the DM channel and inserts the mention

Implementation:
- Add messageInputSuggestion store for cross-component communication
- Update MemberList.handleMentionUser() to use the store and navigate
- Update MessageInput to listen for pending mention insertions

Fixes P3 TODO: 'Insert @mention in message input'
