### PR TITLE
test(webhooks): fix mock interface — add missing methods

### DIFF
--- a/backend/internal/api/handlers/webhooks_test.go
+++ b/backend/internal/api/handlers/webhooks_test.go
@@ -81,6 +81,38 @@ func (m *mockWebhookService) ExecuteWebhook(ctx context.Context, webhookID uuid.
 	return args.Get(0).(*models.Message), args.Error(1)
 }
 
+func (m *mockWebhookService) ExecuteWebhookWithRetry(ctx context.Context, webhookID uuid.UUID, token string, req *services.ExecuteWebhookRequest) (*models.Message, error) {
+	args := m.Called(ctx, webhookID, token, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Message), args.Error(1)
+}
+
+func (m *mockWebhookService) GetWebhookStats(ctx context.Context, webhookID uuid.UUID, requesterID uuid.UUID) (*models.WebhookDeliveryStats, error) {
+	args := m.Called(ctx, webhookID, requesterID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.WebhookDeliveryStats), args.Error(1)
+}
+
+func (m *mockWebhookService) GetWebhookDeliveries(ctx context.Context, webhookID uuid.UUID, requesterID uuid.UUID, limit, offset int) ([]*models.WebhookDelivery, error) {
+	args := m.Called(ctx, webhookID, requesterID, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.WebhookDelivery), args.Error(1)
+}
+
+func (m *mockWebhookService) TestWebhook(ctx context.Context, webhookID uuid.UUID, requesterID uuid.UUID) (*models.Message, error) {
+	args := m.Called(ctx, webhookID, requesterID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Message), args.Error(1)
+}
+
 // --- test app setup ---
 
 func setupWebhookTestApp(t *testing.T, mockService *mockWebhookService) (*fiber.App, uuid.UUID) {
@@ -885,7 +917,8 @@ func TestExecuteWebhook_Success_NoWait(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
+	// Default retry=true uses ExecuteWebhookWithRetry
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
 		ID:        uuid.New(),
 		Content:   "hello",
 		ChannelID: uuid.New(),
@@ -910,7 +943,8 @@ func TestExecuteWebhook_Success_WithWait(t *testing.T) {
 	token := "test-token"
 	msgID := uuid.New()
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
+	// wait=true still uses retry=true by default (uses ExecuteWebhookWithRetry)
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
 		ID:        msgID,
 		Content:   "hello with wait",
 		ChannelID: uuid.New(),
@@ -965,7 +999,7 @@ func TestExecuteWebhook_WebhookNotFound(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -984,7 +1018,7 @@ func TestExecuteWebhook_InvalidToken(t *testing.T) {
 	webhookID := uuid.New()
 	token := "bad-token"
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -1003,7 +1037,7 @@ func TestExecuteWebhook_EmptyMessage(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
 
 	body := `{"content":""}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -1022,7 +1056,7 @@ func TestExecuteWebhook_InternalError(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))


### PR DESCRIPTION
- Add ExecuteWebhookWithRetry, GetWebhookStats, GetWebhookDeliveries,
  TestWebhook to mockWebhookService to match WebhookServiceInterface
- Update test expectations in ExecuteWebhook tests to use
  ExecuteWebhookWithRetry (handler defaults to retry=true)

Fixes build failure in handlers test package.
