### PR TITLE
test(webhooks): fix ExecuteWebhook test mock mismatch

### DIFF
--- a/backend/internal/api/handlers/webhooks_test.go
+++ b/backend/internal/api/handlers/webhooks_test.go
@@ -925,7 +925,7 @@ func TestExecuteWebhook_Success_NoWait(t *testing.T) {
 	}, nil)
 
 	body := `{"content":"hello from webhook"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -950,7 +950,7 @@ func TestExecuteWebhook_Success_WithWait(t *testing.T) {
 	}, nil)
 
 	body := `{"content":"hello with wait"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?wait=true", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?wait=true&retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1000,7 +1000,7 @@ func TestExecuteWebhook_WebhookNotFound(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1019,7 +1019,7 @@ func TestExecuteWebhook_InvalidToken(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1038,7 +1038,7 @@ func TestExecuteWebhook_EmptyMessage(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
 
 	body := `{"content":""}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1057,7 +1057,7 @@ func TestExecuteWebhook_InternalError(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)


### PR DESCRIPTION
The ExecuteWebhook handler calls ExecuteWebhookWithRetry by default (retry=true).
The tests mocked ExecuteWebhook but the handler called ExecuteWebhookWithRetry,
causing a mock panic. Fixed by adding ?retry=false to test URLs so the
handler calls ExecuteWebhook as mocked.
