### PR TITLE
fix: add missing ExecuteWebhook mock setup

### DIFF
--- a/backend/internal/api/handlers/webhooks_test.go
+++ b/backend/internal/api/handlers/webhooks_test.go
@@ -943,8 +943,8 @@ func TestExecuteWebhook_Success_WithWait(t *testing.T) {
 	token := "test-token"
 	msgID := uuid.New()
 
-	// wait=true with retry=false uses ExecuteWebhook directly
-	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
+	// wait=true uses ExecuteWebhookWithRetry
+	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
 		ID:        msgID,
 		Content:   "hello with wait",
 		ChannelID: uuid.New(),
@@ -1002,7 +1002,7 @@ func TestExecuteWebhook_WebhookNotFound(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1021,7 +1021,7 @@ func TestExecuteWebhook_InvalidToken(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1040,7 +1040,7 @@ func TestExecuteWebhook_EmptyMessage(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
 
 	body := `{"content":""}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -1059,7 +1059,7 @@ func TestExecuteWebhook_InternalError(t *testing.T) {
 	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
 
 	body := `{"content":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token+"?retry=false", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)

--- a/backend/internal/api/handlers/webhooks_test.go
+++ b/backend/internal/api/handlers/webhooks_test.go
@@ -943,8 +943,8 @@ func TestExecuteWebhook_Success_WithWait(t *testing.T) {
 	token := "test-token"
 	msgID := uuid.New()
 
-	// wait=true still uses retry=true by default (uses ExecuteWebhookWithRetry)
-	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
+	// wait=true with retry=false uses ExecuteWebhook directly
+	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(&models.Message{
 		ID:        msgID,
 		Content:   "hello with wait",
 		ChannelID: uuid.New(),

--- a/backend/internal/api/handlers/webhooks_test.go
+++ b/backend/internal/api/handlers/webhooks_test.go
@@ -999,7 +999,7 @@ func TestExecuteWebhook_WebhookNotFound(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
+	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrWebhookNotFound)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -1018,7 +1018,7 @@ func TestExecuteWebhook_InvalidToken(t *testing.T) {
 	webhookID := uuid.New()
 	token := "bad-token"
 
-	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
+	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrInvalidWebhookToken)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -1037,7 +1037,7 @@ func TestExecuteWebhook_EmptyMessage(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
+	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, services.ErrEmptyMessage)
 
 	body := `{"content":""}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))
@@ -1056,7 +1056,7 @@ func TestExecuteWebhook_InternalError(t *testing.T) {
 	webhookID := uuid.New()
 	token := "test-token"
 
-	mockService.On("ExecuteWebhookWithRetry", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
+	mockService.On("ExecuteWebhook", mock.Anything, webhookID, token, mock.Anything).Return(nil, assert.AnError)
 
 	body := `{"content":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+webhookID.String()+"/"+token, strings.NewReader(body))


### PR DESCRIPTION
Fixes CI failure in backend-ci where TestExecuteWebhook_Success_NoWait calls ExecuteWebhook (via retry=false) but only had ExecuteWebhookWithRetry mocked.