### PR TITLE
feat(dev): add LiveKit to dev compose + wire voice handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Hearth dev environment template.
+# Copy to `.env` and run `docker compose -f docker-compose.dev.yml up -d`.
+
+# Postgres
+DATABASE_URL=postgres://hearth:hearth@localhost:5432/hearth?sslmode=disable
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# S3-compatible object store (minio in dev)
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=hearth
+S3_REGION=us-east-1
+
+# LiveKit voice / video SFU
+# These keys match the docker-compose.dev.yml LIVEKIT_KEYS entry.
+# Rotate BOTH sides if you expose this outside localhost.
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=devsecretdevsecretdevsecretdevsecret
+LIVEKIT_URL=ws://localhost:7880

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ docker compose up -d
 
 Open `http://localhost:3000`
 
+## Try voice locally (Phase 0 smoke test)
+
+```bash
+docker compose -f docker-compose.dev.yml up -d   # postgres + redis + minio + livekit
+cd backend && go run ./cmd/hearth &
+cd frontend && pnpm install && pnpm dev
+```
+
+Open two browser tabs on `http://localhost:3000`, log in as two different
+users, join the same voice channel. If you can hear yourself round-trip,
+the voice stack is live end-to-end. If the `/voice/token` endpoint 500s
+or the LiveKitManager WebSocket connect hangs, check that
+`LIVEKIT_API_SECRET` matches between `.env` and `docker-compose.dev.yml`
+(32-char minimum).
+
 ## Documentation
 
 - [Deployment Guide](docs/DEPLOYMENT.md) — Docker, Kubernetes, bare metal

--- a/backend/cmd/hearth/main.go
+++ b/backend/cmd/hearth/main.go
@@ -461,6 +461,23 @@ func main() {
 
 	h := handlers.NewHandlersWithTyping(authService, userService, serverService, channelService, messageService, roleService, searchService, threadService, typingService, webhookService, wsGateway, voiceService)
 
+	// Wire up LiveKit voice handler. Without this, routes.go:819 leaves
+	// /voice/token unregistered and the LiveKitManager client 404s on
+	// connect — despite voice_service.go having a full implementation.
+	liveKitVoiceService := services.NewVoiceService(
+		cfg.LiveKitAPIKey,
+		cfg.LiveKitAPISecret,
+		cfg.LiveKitURL,
+		repos.Channels,
+		repos.Servers,
+	)
+	if liveKitVoiceService.IsConfigured() {
+		h.SetLiveKitVoiceHandler(liveKitVoiceService, userService, channelService, permService)
+		log.Printf("✅ LiveKit voice handler wired up (url=%s)", cfg.LiveKitURL)
+	} else {
+		log.Printf("⚠️  LiveKit voice disabled (set LIVEKIT_API_KEY/SECRET/URL to enable)")
+	}
+
 	// Wire up Poll handler
 	h.SetPollHandler(pollService)
 

--- a/backend/internal/api/handlers/handlers.go
+++ b/backend/internal/api/handlers/handlers.go
@@ -272,6 +272,19 @@ func NewHandlersWithTyping(
 	}
 }
 
+// SetLiveKitVoiceHandler wires up the LiveKit voice handler, unlocking the
+// /voice/token, /voice/participants routes (gated in routes.go on
+// h.LiveKitVoice != nil). Without this, the voice_service.go implementation
+// is dead code — the browser client hits /voice/token and gets 404.
+func (h *Handlers) SetLiveKitVoiceHandler(
+	voiceService services.VoiceServiceInterface,
+	userService services.UserServiceInterface,
+	channelService services.ChannelServiceInterface,
+	permService services.VoicePermissionServiceInterface,
+) {
+	h.LiveKitVoice = NewLiveKitVoiceHandler(voiceService, userService, channelService, permService)
+}
+
 // SetScreenShareHandler sets the screen share handler
 func (h *Handlers) SetScreenShareHandler(
 	screenShareService *services.ScreenShareService,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,6 +34,28 @@ services:
     volumes:
       - minio-data:/data
 
+  # LiveKit SFU for voice + video. Uses dev-only keys that match the
+  # backend's LIVEKIT_API_KEY / LIVEKIT_API_SECRET env defaults. Without
+  # this service, the backend's /voice/token endpoint generates tokens
+  # that nowhere can validate and the LiveKitManager WebSocket connect
+  # hangs — which is why voice looks "implemented" but nothing works
+  # end-to-end locally.
+  #
+  # Ports exposed on host:
+  #   7880 (HTTP/WS control plane; the URL the browser connects to)
+  #   7881 (TCP fallback for RTC when UDP is blocked)
+  #   50000-50100 (UDP RTP media — open this range on any local firewall)
+  livekit:
+    image: livekit/livekit-server:latest
+    container_name: hearth-livekit
+    command: --dev --bind 0.0.0.0 --node-ip 127.0.0.1
+    environment:
+      LIVEKIT_KEYS: "devkey: devsecretdevsecretdevsecretdevsecret"
+    ports:
+      - "7880:7880"
+      - "7881:7881"
+      - "50000-50100:50000-50100/udp"
+
 volumes:
   postgres-data:
   redis-data:


### PR DESCRIPTION
## Summary
Two fixes required for voice to work end-to-end:

1. **docker-compose.dev.yml**: add LiveKit SFU in dev mode + `.env.example` with matching keys + README smoke-test section.
2. **main.go**: construct `services.NewVoiceService` + call `h.SetLiveKitVoiceHandler`. Without this, `/voice/token` routes in `routes.go:819` silently don't register (gated on `h.LiveKitVoice != nil`) and the client gets 404 on connect.

## Why #2 matters
During audit, voice_service.go was found to have 284 lines of real LiveKit SDK integration (JWT minting with proper grants, room admin ops). LiveKitVoiceHandler exists in handlers/voice.go. Routes are registered. But the handler was **only** constructed in test files (`routes_test.go:296`). Production `main.go` never wired it, so every `/voice/token` call 404'd. Classic integration gap.

## Test plan
```bash
git pull
cp .env.example .env
docker compose -f docker-compose.dev.yml up -d
cd backend && go run ./cmd/hearth
# logs: "✅ LiveKit voice handler wired up"
cd frontend && pnpm install && pnpm dev
```
Open two tabs on `localhost:3000`, log in as two users, join the same voice channel. If audio round-trips, the full path works.

## Known remaining gaps after this
- `isParticipantSpeaking` returns always-false (voice_service.go:211) — UX papercut, not a blocker
- LiveKit `--dev` mode: no TLS, insecure keys. Fine for laptop; rotate for anything exposed
- UDP 50000-50100 range may need local firewall exception on macOS